### PR TITLE
Add udoprog-heroic-datasource version 0.0.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -173,6 +173,18 @@
           "url": "https://github.com/raintank/snap-app"
         }
       ]
+    },
+    {
+      "id": "udoprog-heroic-datasource",
+      "type": "datasource",
+      "url": "https://github.com/udoprog/udoprog-heroic-datasource",
+      "versions": [
+        {
+          "version": "0.0.1",
+          "commit": "4c922cee6d8127c87bd0f4b7e1e4c4fa22ff2c91",
+          "url": "https://github.com/udoprog/udoprog-heroic-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hey,

So this should introduce udoprog-heroic-datasource, hopefully all good this time.
One thing I noticed last time when attempting to install the previous plugin from grafana.net is that the partials didn't download correctly. Building locally and symlinking the directory to `$GF_PLUGIN_DIR/heroic` works though.

I've created an account on grafana.net now as well.