### PR TITLE
Add Open-Falcon datasource v1.0.0 to the list of available plugins.

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -246,6 +246,18 @@
           "url": "https://github.com/udoprog/udoprog-heroic-datasource"
         }
       ]
+    },
+    {
+      "id": "fastweb-openfalcon-datasource",
+      "type": "datasource",
+      "url": "https://github.com/open-falcon/grafana-openfalcon-datasource",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "795af2363a0443014906c35615d25e7ef2dd44a6",
+          "url": "https://github.com/open-falcon/grafana-openfalcon-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
See also: https://github.com/grafana/grafana/pull/3787