### PR TITLE
Add udoprog-heroic-datasource version 0.1.0 (replace 0.0.1)

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -316,6 +316,11 @@
           "version": "0.0.1",
           "commit": "4c922cee6d8127c87bd0f4b7e1e4c4fa22ff2c91",
           "url": "https://github.com/udoprog/udoprog-heroic-datasource"
+        },
+        {
+          "version": "0.1.0",
+          "commit": "ebe7dffb02b0843b34b043786f651ad02205c417",
+          "url": "https://github.com/udoprog/udoprog-heroic-datasource"
         }
       ]
     },


### PR DESCRIPTION
There was an incompatible change from one of the Beta versions which made the input field break (see https://github.com/udoprog/udoprog-heroic-datasource/pull/2), so there's no good reason to keep version `0.0.1` around.