### PR TITLE
Add stagemonitor-grafana-elasticsearch app

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -372,6 +372,18 @@
           "url": "https://github.com/percona/grafana-app"
         }
       ]
+    },
+    {
+      "id": "stagemonitor-grafana-elasticsearch",
+      "type": "app",
+      "url": "https://github.com/stagemonitor/stagemonitor-grafana-elasticsearch",
+      "versions": [
+        {
+          "version": "0.26.0",
+          "commit": "",
+          "url": "https://github.com/stagemonitor/stagemonitor-grafana-elasticsearch"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -380,7 +380,7 @@
       "versions": [
         {
           "version": "0.26.0",
-          "commit": "",
+          "commit": "f05cb00ff8b2f2a77b2a570a4d9f6c54bd0099f1",
           "url": "https://github.com/stagemonitor/stagemonitor-grafana-elasticsearch"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -374,7 +374,7 @@
       ]
     },
     {
-      "id": "stagemonitor-grafana-elasticsearch",
+      "id": "stagemonitor-elasticsearch-app",
       "type": "app",
       "url": "https://github.com/stagemonitor/stagemonitor-grafana-elasticsearch",
       "versions": [


### PR DESCRIPTION
0.26.0 is not released yet, thus the commit hash is empty.

If you think the https://github.com/stagemonitor/stagemonitor-grafana-elasticsearch looks good, I'll release the final version.

I've already created a stagemonitor organization on grafana.net.