### PR TITLE
Add grafana-sunandmoon-datasource plugin (v0.1.0)

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -455,6 +455,18 @@
           "url": "https://github.com/mtanda/grafana-heatmap-epoch-panel"
         }
       ]
+    },
+    {
+      "id": "fetzerch-sunandmoon-datasource",
+      "type": "datasource",
+      "url": "https://github.com/fetzerch/grafana-sunandmoon-datasource",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "commit": "b4cb66988aca9b59576b15e762c5fcda056bde08",
+          "url": "https://github.com/fetzerch/grafana-sunandmoon-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
I've been working on a small datasource plugin, that calculates the sun and moon position - useful, if you use Grafana for weather station projects.

![Screenshot](https://raw.githubusercontent.com/fetzerch/grafana-sunandmoon-datasource/master/src/img/screenshot.png)

Since it's my first JS project, a code review would be highly appreciated.

I'm using Grafana for my [atMETEO](https://fetzerch.github.io/2015/05/20/atmeteo/) project and this is how I make use of the datasource in a bigger dashboard. It's useful to see for example the current moon phase or sunrise / sunset times.
![atMETEO grafana](https://fetzerch.github.io/assets/atmeteo_grafana.png)

I'd be happy if this could get added to grafana.net.
Cheers,
Christian