### PR TITLE
add briangann-gauge-panel (d3 gauge)

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -632,6 +632,18 @@
           "url": "https://github.com/jdbranham/grafana-diagram"
         }
       ]
+    },
+    {
+      "id": "briangann-gauge-panel",
+      "type": "panel",
+      "url": "https://github.com/briangann/grafana-gauge-panel",
+      "versions": [
+        {
+          "version": "0.0.1",
+          "commit": "42f1637cdf3c4cdc6121a4652149dc6670af549b",
+          "url": "https://github.com/briangann/grafana-gauge-panel"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Here's a D3-based Gauge panel for Grafana. Many thanks to Dan Cech for cleaning up the issues needed for integration.

See https://github.com/briangann/grafana-gauge-panel for source/doc/etc.

Verified working on Chrome/Firefox/Safari, and will work with all datasources compatible with SingleStat.

Thanks!

Brian
