### PR TITLE
Add neocat-cal-heatmap-panel entry

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -778,6 +778,18 @@
           "url": "https://github.com/ryantxu/ajax-panel"
         }
       ]
+    },
+    {
+      "id": "neocat-cal-heatmap-panel",
+      "type": "panel",
+      "url": "https://github.com/NeoCat/grafana-cal-heatmap-panel",
+      "versions": [
+        {
+          "version": "0.0.2",
+          "commit": "edff2df73d699edb27f9bb3ec1f53a22fe4fc04d",
+          "url": "https://github.com/NeoCat/grafana-cal-heatmap-panel"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This plugin provides a calendar view with heatmap, like GitHub contribution calendar.