### PR TITLE
Update neocat-cal-heatmap-panel to 0.0.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -878,6 +878,11 @@
           "version": "0.0.2",
           "commit": "edff2df73d699edb27f9bb3ec1f53a22fe4fc04d",
           "url": "https://github.com/NeoCat/grafana-cal-heatmap-panel"
+        },
+        {
+          "version": "0.0.3",
+          "commit": "491f2572eb575ed69972a1577074a8a7a5a181ff",
+          "url": "https://github.com/NeoCat/grafana-cal-heatmap-panel"
         }
       ]
     },


### PR DESCRIPTION
This will update neocat-cal-heatmap-panel to 0.0.3.

- Now thresholds are automatically calculated when the option is empty
- Supported UTC timestamp
- Optionally hyperlink can be specified for cells
- Values displayed on mouse hover are now formatted by kbn.valueFormater
- Other some bug fixes