### PR TITLE
Add Satellogic 3D Globe Panel 0.1.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -958,6 +958,18 @@
           "url": "https://github.com/Vonage/Grafana_Status_panel"
         }
       ]
+    },
+    {
+      "id": "satellogic-3d-globe-panel",
+      "type": "panel",
+      "url": "https://github.com/satellogic/grafana-3d-globe-panel",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "commit": "0930ebe33a023b71d0a55c9be29566b6fe8e231d",
+          "url": "https://github.com/satellogic/grafana-3d-globe-panel"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This new plugin allows you to add a cesium panel to your dashboard, and define a custom URL for your CZML data file to add elements to the map.

Not sure if this is the right place, but this plugin should be published under https://grafana.net/orgs/satellogic in grafana.net