### PR TITLE
add clickhouse-grafana datsource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1022,6 +1022,18 @@
           "url": "https://github.com/openstack/monasca-grafana-datasource"
         }
       ]
+    },
+    {
+      "id": "clickhouse-grafana",
+      "type": "datasource",
+      "url": "https://github.com/Vertamedia/clickhouse-grafana",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "d55f7a36e40642be64879740e719409a3742488c",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -1030,7 +1030,7 @@
       "versions": [
         {
           "version": "0.0.1",
-          "commit": "103264210c1547d4182c79f2dfadecb442d75fcf",
+          "commit": "7ec2bb0efa5972e283c9cbe5e76d930ead94a18b",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -1024,13 +1024,13 @@
       ]
     },
     {
-      "id": "clickhouse-grafana",
+      "id": "vertamedia-clickhouse-datasource",
       "type": "datasource",
       "url": "https://github.com/Vertamedia/clickhouse-grafana",
       "versions": [
         {
-          "version": "1.0.0",
-          "commit": "d55f7a36e40642be64879740e719409a3742488c",
+          "version": "0.0.1",
+          "commit": "103264210c1547d4182c79f2dfadecb442d75fcf",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -1030,7 +1030,7 @@
       "versions": [
         {
           "version": "0.0.1",
-          "commit": "7ec2bb0efa5972e283c9cbe5e76d930ead94a18b",
+          "commit": "1da0a28e68dfb5f8fd87d804865bd0db0e49fe46",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]


### PR DESCRIPTION
Hi! We've created datasource plugin for [ClickHouse](https://github.com/yandex/ClickHouse) database

ps plugin should be published under https://grafana.net/orgs/vertamediallc in grafana.net