### PR TITLE
Releasing Grafana Druid Plugin 0.0.3 & 0.0.4

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -716,6 +716,16 @@
       "url": "https://github.com/grafana-druid-plugin/druidplugin",
       "versions": [
         {
+          "version": "0.0.4",
+          "commit": "a38c792489bfdbf0074436811314eae47dc4264a",
+          "url": "https://github.com/grafana-druid-plugin/druidplugin"
+        },
+        {
+          "version": "0.0.3",
+          "commit": "d0b59f4b6fa9c3d21408fd0a29e8c553f4404336",
+          "url": "https://github.com/grafana-druid-plugin/druidplugin"
+        },
+        {
           "version": "0.0.2",
           "commit": "5ef5398c14fb368ab3abfeb58c092cea4af358b9",
           "url": "https://github.com/grafana-druid-plugin/druidplugin"

--- a/repo.json
+++ b/repo.json
@@ -717,13 +717,13 @@
       "versions": [
         {
           "version": "0.0.4",
-          "commit": "a38c792489bfdbf0074436811314eae47dc4264a",
+          "commit": "84d7ae669c4585079041e31600e34c6eda829389",
           "url": "https://github.com/grafana-druid-plugin/druidplugin"
         },
         {
           "version": "0.0.3",
-          "commit": "d0b59f4b6fa9c3d21408fd0a29e8c553f4404336",
-          "url": "https://github.com/grafana-druid-plugin/druidplugin"
+          "commit": "e7db162c9fc3d687663de64640284ec3383ce9ac",
+          "url": "https://github.com/grafana-druid-plugin/druidplugin/tree/grafana-3.x.x"
         },
         {
           "version": "0.0.2",


### PR DESCRIPTION
Release Notes:
Plugin Version 0.0.3:

- Added plugin build scripts:
- Fixed a bug: (Can't add approxHistogramFold to Aggregators #2
)https://github.com/grafana-druid-plugin/druidplugin/issues/2

Plugin Version 0.0.4:
- Added support for Grafana-4-x-x
- Fixed bug: (error on Timeseries with Grafana 4.1.2 #8
) https://github.com/grafana-druid-plugin/druidplugin/issues/8
