### PR TITLE
Update D3Gauge plugin version to 0.0.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -826,6 +826,11 @@
       "url": "https://github.com/briangann/grafana-gauge-panel",
       "versions": [
         {
+          "version": "0.0.3",
+          "commit": "f969574179727eea85404cfb48687ff1e58a7711",
+          "url": "https://github.com/briangann/grafana-gauge-panel"
+        },
+        {
           "version": "0.0.2",
           "commit": "abf3e0249f4d177bc60bfac363c10e83fa2348c0",
           "url": "https://github.com/briangann/grafana-gauge-panel"


### PR DESCRIPTION
This release fixes a number of bugs and adds some new features.

Bugfixes:
 * Extra gauge no longer appears when using "duplicate"
 * Now correctly sizes according to panel settings (Height and Width)
 * Needle animation works as intended 

New Features:
  * Needle animation speed is now configurable
  * Arbitrary degree gauges now supported (default is from 60 to 320)
  * Start of 0 value in gauge can be set to any degree
  * Value text on gauge can now be moved up/down as needed (Useful for full-circle gauges)

