### PR TITLE
add google calendar annotation datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1178,6 +1178,18 @@
           "url": "https://github.com/sni/grafana-pnp-datasource"
         }
       ]
+    },
+    {
+      "id": "mtanda-google-calendar-datasource",
+      "type": "datasource",
+      "url": "https://github.com/mtanda/grafana-google-calendar-datasource",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "490219a3d64de5d42c6d8a0e209e2477c3033b92",
+          "url": "https://github.com/mtanda/grafana-google-calendar-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This is a datasource, annotate schedule to graph.
Use case: annotation new feature release date, campaign date, or something

I'm not sure such strange data source plugin is acceptable for grafana.net.
If it is acceptable, I'll prepare screenshot and README.