### PR TITLE
Add status dot panel and update alarm box

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -35,6 +35,18 @@
       ]
     },
     {
+      "id": "btplc-status-dot-panel",
+      "type": "panel",
+      "url": "https://github.com/BTplc/grafana-status-dot",
+      "versions": [
+        {
+          "version": "0.0.1",
+          "commit": "c493f4924a5649cee42a2015231d2689ea73943a",
+          "url": "https://github.com/BTplc/grafana-status-dot"
+        }
+      ]
+    },
+    {
       "id": "btplc-alarm-box-panel",
       "type": "panel",
       "url": "https://github.com/BTplc/grafana-alarm-box",
@@ -52,6 +64,11 @@
         {
           "version": "0.1.0",
           "commit": "e87cbdee2f1628037099b52cb303e10174b680c7",
+          "url": "https://github.com/BTplc/grafana-alarm-box"
+        },
+        {
+          "version": "0.1.1",
+          "commit": "faf540af64689b39d2b879d6c03023800f2ac1dd",
           "url": "https://github.com/BTplc/grafana-alarm-box"
         }
       ]


### PR DESCRIPTION
We'd like to add a new Status Dot panel, which is similar to existing Trend Dot plugin, but less restrictive. It displays a dot for each (Graphite) series, colored using configurable expressions.

In fact, we'd like to discontinue/remove the btplc-trend-dot-panel plugin we published previously, as we don't use it and are unlikely to maintain it. It's pretty niche! What are your thoughts on this?