### PR TITLE
Adding michaeldmoore-annunciator-panel to repo.json

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1391,6 +1391,18 @@
           "url": "https://github.com/petrslavotinek/grafana-carpetplot"
         }
       ]
+    },
+    {
+      "id": "michaeldmoore-annunciator-panel",
+      "type": "panel",
+      "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "41d300f69d09d44994cb21207ef53e0c188e109a",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -1404,7 +1404,7 @@
         }
         {
           "version": "1.0.1",
-          "commit": "7f7f5602e913078a98701328248ae206994d851e",
+          "commit": "542707e504b1461bb6fb70b86c8a637f93724181",
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -1402,6 +1402,11 @@
           "commit": "41d300f69d09d44994cb21207ef53e0c188e109a",
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
         }
+        {
+          "version": "1.0.1",
+          "commit": "7f7f5602e913078a98701328248ae206994d851e",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+        }
       ]
     }
   ]


### PR DESCRIPTION
Contributing a useful panel based on SingleStat, but with enhanced display options for showing/flashing upper and lower limits and warning levels.