### PR TITLE
Zabbix plugin v3.6.1 (quick minor fix)

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -183,6 +183,11 @@
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
         {
+          "version": "3.6.1",
+          "commit": "4c39fec00754dac434b85ca81ca1f589a58c223b",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix"
+        },
+        {
           "version": "3.6.0",
           "commit": "ec272770bb69056df979b7b4b17c18b153ca3c81",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix"


### PR DESCRIPTION
Fix error after upgrade due missing json options for new connection mode