### PR TITLE
Added Simple Annotations Datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1550,7 +1550,7 @@
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "af442ce5beaa3665aaf17594fe51a608805cd4bc",
+          "commit": "2df0c9cca6b11e822d96580da3c7bf14465c0d7a",
           "url": "https://github.com/fzakaria/simple-annotations-plugin"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -1544,7 +1544,7 @@
       ]
     },
     {
-      "id": "simple-annotations-datasource",
+      "id": "fzakaria-simple-annotations-datasource",
       "type": "datasource",
       "url": "https://github.com/fzakaria/simple-annotations-plugin",
       "versions": [

--- a/repo.json
+++ b/repo.json
@@ -1542,6 +1542,18 @@
           "url": "https://github.com/rafal-szypulka/grafana-ibm-apm"
         }
       ]
+    },
+    {
+      "id": "simple-annotations-datasource",
+      "type": "datasource",
+      "url": "https://github.com/fzakaria/simple-annotations-plugin",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "0383743f380069227350528211f222a44155e28a",
+          "url": "https://github.com/fzakaria/simple-annotations-plugin"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -1550,7 +1550,7 @@
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "0383743f380069227350528211f222a44155e28a",
+          "commit": "af442ce5beaa3665aaf17594fe51a608805cd4bc",
           "url": "https://github.com/fzakaria/simple-annotations-plugin"
         }
       ]


### PR DESCRIPTION
Created a Grafana plugin that allows annotations to be easily added to any graph.
It uses the `dashboard.json` itself as the datasource.

I understand that eventually Grafana will support its own annotation table -- however in the mean time this plugin is extremely useful and can be used by older versions of Grafana.