### PR TITLE
Adding grafana-warp10-datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1850,7 +1850,7 @@
       "versions": [
         {
           "version": "1.2.4",
-          "commit": "f82b4f0ea529d63d710c0455335375464978f92d",
+          "commit": "690b96458434c431ed759924832c5533101079f1",
           "url": "https://github.com/cityzendata/grafana-warp10"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -1783,6 +1783,16 @@
           "url": "https://github.com/ntop/ntopng-grafana-datasource"
         }
       ]
-    }
+    },
+    {
+      "id": "grafana-warp10-datasource",
+      "type": "datasource",
+      "url": "https://github.com/cityzendata/grafana-warp10",
+      "versions": [
+        {
+          "version": "1.2.3",
+          "commit": "e11dc9e5c079a823f2e0d23567c81859df79be3e",
+          "url": "https://github.com/cityzendata/grafana-warp10"
+        }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -1794,5 +1794,7 @@
           "commit": "e11dc9e5c079a823f2e0d23567c81859df79be3e",
           "url": "https://github.com/cityzendata/grafana-warp10"
         }
+      ]
+    }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -1817,7 +1817,7 @@
       ]
     },
     {
-      "id": "grafana-warp10-datasource",
+      "id": "warp10-datasource",
       "type": "datasource",
       "url": "https://github.com/cityzendata/grafana-warp10",
       "versions": [

--- a/repo.json
+++ b/repo.json
@@ -1790,8 +1790,8 @@
       "url": "https://github.com/cityzendata/grafana-warp10",
       "versions": [
         {
-          "version": "1.2.3",
-          "commit": "e11dc9e5c079a823f2e0d23567c81859df79be3e",
+          "version": "1.2.4",
+          "commit": "f82b4f0ea529d63d710c0455335375464978f92d",
           "url": "https://github.com/cityzendata/grafana-warp10"
         }
       ]


### PR DESCRIPTION
Adding Grafana  Warp 10 Datasource Plugin, a plugin that allows Grafana 4 to support [Warp 10](http://www.warp10.io/) as datasource.