### PR TITLE
Bump hawkular datasource 1.1.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1186,6 +1186,11 @@
           "version": "1.0.10",
           "commit": "32ba7bf889a8e36fa292ccbec7c13aee33d48b3f",
           "url": "https://github.com/hawkular/hawkular-grafana-datasource"
+        },
+        {
+          "version": "1.1.1",
+          "commit": "00fa4ebe1b6c2365a3ee699ec638bebc906b807a",
+          "url": "https://github.com/hawkular/hawkular-grafana-datasource"
         }
       ]
     },


### PR DESCRIPTION
Includes following releases:
- https://github.com/hawkular/hawkular-grafana-datasource/releases/tag/v1.1.0
- https://github.com/hawkular/hawkular-grafana-datasource/releases/tag/v1.1.1

Note that any previous datasource configuration must be modified manually, or recreated:
Server URL like `http://myserver:123/hawkular/metrics` must be changed to `http://myserver:123/hawkular`