### PR TITLE
Update GPA openHistorian datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1077,7 +1077,7 @@
         },
         {
           "version": "1.0.2",
-          "commit": "1b3e8e3a50a9ac5a665ddf547069cfbb8695f72e",
+          "commit": "718f5fcc53376b6af790bc66367bd2c53c6e6321",
           "url": "https://github.com/GridProtectionAlliance/openHistorian-grafana"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -1074,6 +1074,11 @@
           "version": "1.0.1",
           "commit": "471a73bd1156dabf169a1b0cf7c75334561c5c5a",
           "url": "https://github.com/GridProtectionAlliance/openHistorian-grafana"
+        },
+        {
+          "version": "1.0.2",
+          "commit": "1b3e8e3a50a9ac5a665ddf547069cfbb8695f72e",
+          "url": "https://github.com/GridProtectionAlliance/openHistorian-grafana"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -1077,7 +1077,7 @@
         },
         {
           "version": "1.0.2",
-          "commit": "718f5fcc53376b6af790bc66367bd2c53c6e6321",
+          "commit": "7e1ae02027793b4b7dc45a0eaf36e4ede5f435ec",
           "url": "https://github.com/GridProtectionAlliance/openHistorian-grafana"
         }
       ]


### PR DESCRIPTION
This update enhances the Grafana data source plugin for the openHistorian to version 1.0.2 with new query builder screens and adds better documentation.

Note that this version also creates a `dist` sub-folder for the target distribution files where the prior versions did not, in case this is relevant to the import process.