### PR TITLE
Update GPA openHistorian datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1074,6 +1074,11 @@
           "version": "1.0.1",
           "commit": "471a73bd1156dabf169a1b0cf7c75334561c5c5a",
           "url": "https://github.com/GridProtectionAlliance/openHistorian-grafana"
+        },
+        {
+          "version": "1.0.2",
+          "commit": "a2b515076e192f3b6f0766d960f77374d20bb5ec",
+          "url": "https://github.com/GridProtectionAlliance/openHistorian-grafana"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -1077,7 +1077,7 @@
         },
         {
           "version": "1.0.2",
-          "commit": "a2b515076e192f3b6f0766d960f77374d20bb5ec",
+          "commit": "4071fe914b2f79a0ea34dd2b92b8a1b3dc80813b",
           "url": "https://github.com/GridProtectionAlliance/openHistorian-grafana"
         }
       ]


### PR DESCRIPTION
This update enhances the Grafana data source plugin for the openHistorian to version 1.0.2 with new query builder screens and adds better documentation.

Note that this version also creates a `dist` sub-folder for the target distribution files where the prior versions did not, in case this is relevant to the import process.