### PR TITLE
add humio2grafana datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1977,6 +1977,11 @@
           "version": "1.0.2",
           "commit": "9a18261eee1a7aed5e7bc0897ba8f2481615330d",
           "url": "https://github.com/humio/humio2grafana"
+        },
+        {
+          "version": "1.0.3",
+          "commit": "f99c907ba4e7e4f30ea8e85da512e9e1558e2d3f",
+          "url": "https://github.com/humio/humio2grafana"
         }
       ]
     }

--- a/repo.json
+++ b/repo.json
@@ -1967,6 +1967,18 @@
           "url": "https://github.com/devicehive/devicehive-grafana-datasource"
         }
       ]
+    },
+    {
+      "id": "humio-humio2grafana-datasource",
+      "type": "datasource",
+      "url": "https://github.com/humio/humio2grafana",
+      "versions": [
+        {
+          "version": "1.0.2",
+          "commit": "9a18261eee1a7aed5e7bc0897ba8f2481615330d",
+          "url": "https://github.com/humio/humio2grafana"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR adds humio2grafana datasource plugin. Humio is log management without limits. Query, aggregate, and visualize your application data instantly, on-premise or in the cloud.
https://www.humio.com/