### PR TITLE
Update datatable panel to 0.0.6 for v5 compatibility and other bugfixes

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1172,6 +1172,11 @@
       "url": "https://github.com/briangann/grafana-datatable-panel",
       "versions": [
         {
+          "version": "0.0.6",
+          "commit": "72dc7c598d7334eb9f7e8386eb782975acefe578",
+          "url": "https://github.com/briangann/grafana-datatable-panel"
+        },
+        {
           "version": "0.0.3",
           "commit": "6046f38006ba6bb06cf8188a6ac81c295c37e46c",
           "url": "https://github.com/briangann/grafana-datatable-panel"


### PR DESCRIPTION
Changes since v0.0.3:

0.0.4  NEW: Now autoscrolls horizontally if number of columns is wider than the rendered panel
0.0.5  BUGFIX: SystemJS path changes for Grafana > 4.6 (root subpath bug)
0.0.6  BUGFIX: Compatibility for v5 (panel height bug), updated NPM modules