### PR TITLE
update d3gauge panel to 0.0.5 for grafana v5 compatibility

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1145,6 +1145,11 @@
       "url": "https://github.com/briangann/grafana-gauge-panel",
       "versions": [
         {
+          "version": "0.0.5",
+          "commit": "0f1e7fe60bd327c1405f36bbd386018f68f79c93",
+          "url": "https://github.com/briangann/grafana-gauge-panel"
+        },
+        {
           "version": "0.0.4",
           "commit": "976e74d24afe865554be33bb85f4f2764d3184f9",
           "url": "https://github.com/briangann/grafana-gauge-panel"


### PR DESCRIPTION
This release contains a minor fix for determining panel height that was not compatible with grafana v5.

Verified this works with v3.1.1, v4.6.3, and latest v5 beta.