### PR TITLE
IBM APM plugin 0.8

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1977,7 +1977,7 @@
       "versions": [
         {
           "version": "0.8.0",
-          "commit": "500273d9f71eb79d3d7e5f84103bdc30485cbaad",
+          "commit": "bedfdbeffe9b1b7059402f723bd37bd41e45e8e8",
           "url": "https://github.com/rafal-szypulka/grafana-ibm-apm"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -1951,8 +1951,8 @@
       "url": "https://github.com/rafal-szypulka/grafana-ibm-apm",
       "versions": [
         {
-          "version": "0.4",
-          "commit": "655b29a739a4f45a3e74189948333c14ee1b4b34",
+          "version": "0.8",
+          "commit": "500273d9f71eb79d3d7e5f84103bdc30485cbaad",
           "url": "https://github.com/rafal-szypulka/grafana-ibm-apm"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -1951,7 +1951,7 @@
       "url": "https://github.com/rafal-szypulka/grafana-ibm-apm",
       "versions": [
         {
-          "version": "0.8",
+          "version": "0.8.0",
           "commit": "500273d9f71eb79d3d7e5f84103bdc30485cbaad",
           "url": "https://github.com/rafal-szypulka/grafana-ibm-apm"
         }


### PR DESCRIPTION
Changes since the last published version (0.4):
- 0.8
  - Added support for string metrics, thx [@lcollin](https://github.com/lcollin)
  - Added example dashboard for Node.js application running in IBM Cloud Private.
  - Simplified installation for Grafana 5. Plugin works correctly without modifications in Grafana 5 backend (thanks to Grafana 5 new feature [#5457](https://github.com/grafana/grafana/issues/5457)).
- 0.7
  - Fixed compatibility issue with Grafana 4.6
  - More readible dropdown lists in panel query editor.
- 0.6
  - Added datasource configuration option to deallocate dataset on ITM/APM server after every metric query. Lack of dataset deallocation may cause memory leak and OutOfMemory exceptions on ITM/APM server. This plugin update requires also change in the Grafana server backend for Grafana 4.x. See updated installation instructions and datasource configuration for details.