### PR TITLE
* updated vonage status panel to version 1.0.8 - Grafana 5.0.x support

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1530,6 +1530,11 @@
       "url": "https://github.com/Vonage/Grafana_Status_panel",
       "versions": [
         {
+          "version": "1.0.8",
+          "commit": "e1cadda944c9b6c56a2bca9ada11422a432cd7f2",
+          "url": "https://github.com/Vonage/Grafana_Status_panel"
+        },
+        {
           "version": "1.0.7",
           "commit": "d5173e4aeffe46ddc0433423a37e032a24ea40dd",
           "url": "https://github.com/Vonage/Grafana_Status_panel"


### PR DESCRIPTION
Hi,
Added support for Grafana 5.0.x
commit hash: e1cadda944c9b6c56a2bca9ada11422a432cd7f2

Thanks!