### PR TITLE
Update clickhouse-datasource to 1.4.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1720,6 +1720,11 @@
           "version": "1.4.1",
           "commit": "f76cefb6b18237013d6e7a6c7b1fcec937dede6c",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "1.4.3",
+          "commit": "c2d1965efccad8eeb777afe659597609e4c975ba",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -1685,6 +1685,11 @@
           "version": "1.3.1",
           "commit": "cf6d60e95bf569a0212795390c053ba12a0d0857",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "1.4.1",
+          "commit": "f76cefb6b18237013d6e7a6c7b1fcec937dede6c",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },


### PR DESCRIPTION
* fix broken AST when using nested SELECT without FROM statement (#45)
* strict statement matching (#44)
* rebuild queries from AST only if adhoc filters were applied
* support UNION ALL statements
* proper format for LIMIT N,M construction (thx to @shankerwangmiao)
* update Show Help section with $unescape description