### PR TITLE
Added grafana-http-json-datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -624,6 +624,18 @@
       ]
     },
     {
+      "id": "exozet-http-json-datasource",
+      "type": "datasource",
+      "url": "https://github.com/exozet/grafana-http-json-datasource",
+      "versions": [
+        {
+          "version": "1.4.0",
+          "commit": "31994fc70283ded33b56af28635d8586e1218d26",
+          "url": "https://github.com/exozet/grafana-http-json-datasource"
+        }
+      ]
+    },
+    {
       "id": "opennms-helm",
       "type": "app",
       "url": "https://github.com/OpenNMS/opennms-helm",


### PR DESCRIPTION
Since simple json currently lags adhoc filter support (PR is also created https://github.com/grafana/simple-json-datasource/pull/91 ), I thought it might be a good idea to keep simple json datasource small and add extra features to an extra data source called "http json datasource".

<img width="825" alt="bildschirmfoto 2018-04-17 um 00 38 26" src="https://user-images.githubusercontent.com/35926/38838829-53fe1ef4-41d8-11e8-8750-281ea1364147.png">
