### PR TITLE
Update repo.json to add michaeldmoore-multistat-panel

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1972,6 +1972,18 @@
       ]
     },
     {
+      "id": "michaeldmoore-multistat-panel",
+      "type": "panel",
+      "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel",
+      "versions": [
+        {
+          "version": "1.1.0",
+          "commit": "620894eed6b1724ac6aa6babbdfef58e584cf4f7",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        }
+      ]
+    },    
+    {
       "id": "jasonlashua-prtg-datasource",
       "type": "datasource",
       "url": "https://github.com/neuralfraud/grafana-prtg/jasonlashua-prtg-datasource",


### PR DESCRIPTION
At long last, I've addressed the outstanding features to the multistat panel I tried to release some time ago. Fingers crossed, it addressed averything you had pointed out int eh earlier review - plus a lot, lot more. i think it is a pretty powerful addition, serving, especially, process monitoring dashboards.

I'm adding this to the repo.json

{
 "id": "michaeldmoore-multistat-panel",
 "type": "panel",
 "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel",
 "versions": [
 {
 "version": "1.1.0",
 "commit": "620894eed6b1724ac6aa6babbdfef58e584cf4f7",
 "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
 }
 ]
 },

