### PR TITLE
Submit kairosdb-datasource 3.0.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -536,8 +536,8 @@
       "url": "https://github.com/grafana/kairosdb-datasource",
       "versions": [
         {
-          "version": "3.0.0",
-          "commit": "25deaea9473b63804528b6a0caa6627c26c7562a",
+          "version": "3.0.1",
+          "commit": "1335dffdc9580cdbf90df3c9ee4ffb63a7c90ab8",
           "url": "https://github.com/grafana/kairosdb-datasource"
         },
         {

--- a/repo.json
+++ b/repo.json
@@ -536,6 +536,11 @@
       "url": "https://github.com/grafana/kairosdb-datasource",
       "versions": [
         {
+          "version": "3.0.0",
+          "commit": "25deaea9473b63804528b6a0caa6627c26c7562a",
+          "url": "https://github.com/grafana/kairosdb-datasource"
+        },
+        {
           "version": "2.0.1",
           "commit": "2646222f867ee0894266244669a6f0a2b775375e",
           "url": "https://github.com/grafana/kairosdb-datasource"


### PR DESCRIPTION
This PR is to address grafana/kairosdb-datasource#68

It points to the 3.0.0 commit