### PR TITLE
Update clickhouse-datasource to 1.5.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1760,6 +1760,11 @@
           "version": "1.4.3",
           "commit": "c2d1965efccad8eeb777afe659597609e4c975ba",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "1.5.0",
+          "commit": "381274868299d9b76cdf2c752c42c2f9e80f9c7d",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -1720,6 +1720,11 @@
           "version": "1.4.1",
           "commit": "f76cefb6b18237013d6e7a6c7b1fcec937dede6c",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "1.4.3",
+          "commit": "c2d1965efccad8eeb777afe659597609e4c975ba",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -1685,6 +1685,11 @@
           "version": "1.3.1",
           "commit": "cf6d60e95bf569a0212795390c053ba12a0d0857",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "1.4.1",
+          "commit": "f76cefb6b18237013d6e7a6c7b1fcec937dede6c",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },


### PR DESCRIPTION
* new datasource setting - `default database`. If set it will be prefilled in the query builder, and used to make ad-hoc filters more convenient (thx to @vavrusa)
* support wildcard ad-hoc filters for dashboards using multiple tables (thx to @vavrusa)
* parse dimensions from GROUP BY to simplify querying (see [piechart](https://github.com/Vertamedia/clickhouse-grafana#piechart-httpsgrafanacompluginsgrafana-piechart-panel) and [worldmap](https://github.com/Vertamedia/clickhouse-grafana#worldmap-panel-httpsgithubcomgrafanaworldmap-panel) examples) (thx to @vavrusa)
* `$timeCol` to `$dateCol` renamed to be more clear with column types (thx to @simPod)

