### PR TITLE
Added linksmart-sensorthings-datasource v1.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2317,7 +2317,7 @@
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "5b22b02aff5402f2e8f98d65e9a0dac4f230ac20",
+          "commit": "17836e2ede426fa323c484a681fe74ca91602ae5",
           "url": "https://github.com/farshidtz/linksmart-sensorthings-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2309,6 +2309,18 @@
           "url": "https://github.com/GoshPosh/grafana-meta-queries"
         }
       ]
+    },
+    {
+      "id": "linksmart-sensorthings-datasource",
+      "type": "datasource",
+      "url": "https://github.com/farshidtz/linksmart-sensorthings-datasource",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "5b22b02aff5402f2e8f98d65e9a0dac4f230ac20",
+          "url": "https://github.com/farshidtz/linksmart-sensorthings-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hi,

I would like to submit this plugin which enables the visualization of sensor and location data from an [OGC SensorThings](https://github.com/opengeospatial/sensorthings).

SensorThings server and dummy data faker to test the plugin: https://code.linksmart.eu/projects/OGC-ST/repos/sensorthings-datasource-demo

Btw, is it possible to use non-Github Git repositories as url in repo.json?

Thanks,