### PR TITLE
Release Plotly 0.0.5

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1384,6 +1384,11 @@
       "url": "https://github.com/NatelEnergy/grafana-plotly-panel",
       "versions": [
         {
+          "version": "0.0.5",
+          "commit": "70ab7fbb9203565dc405a037123fc6904f8bacec",
+          "url": "https://github.com/NatelEnergy/grafana-plotly-panel"
+        },
+        {
           "version": "0.0.4",
           "commit": "df51dc99e63c781f2ddc9590b7f106e40648738d",
           "url": "https://github.com/NatelEnergy/grafana-plotly-panel"

--- a/repo.json
+++ b/repo.json
@@ -1385,7 +1385,7 @@
       "versions": [
         {
           "version": "0.0.5",
-          "commit": "70ab7fbb9203565dc405a037123fc6904f8bacec",
+          "commit": "8bb9fad0a2da04b943116cf91ad0bb56885d0fb1",
           "url": "https://github.com/NatelEnergy/grafana-plotly-panel"
         },
         {

--- a/repo.json
+++ b/repo.json
@@ -1402,7 +1402,7 @@
       "versions": [
         {
           "version": "0.0.5",
-          "commit": "8bb9fad0a2da04b943116cf91ad0bb56885d0fb1",
+          "commit": "fd20e71fc45a59475fb2f1fdde687f93978bde18",
           "url": "https://github.com/NatelEnergy/grafana-plotly-panel"
         },
         {


### PR DESCRIPTION
Update to the plotly panel:

v0.0.5
- Upgrade plotly (v1.39+)
- Better support for light theme. (#24, @cscheuermann81)
- Support snapshots
- Removing dist from master branch
- Support of multiple time series's (#9, CorpGlory DevTeam)
- Support showing text from query (#11)
- Template variable support

One key change is that the `dist` folder is not in master branch anymore -- this will make patches a bit better!  Hopefully the grafana plugin infrastructure is based just on the hash, not on any assumptions of the branch :) 

https://github.com/NatelEnergy/grafana-plotly-panel/tree/70ab7fbb9203565dc405a037123fc6904f8bacec/dist 
