### PR TITLE
Add Darksky API plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2357,13 +2357,13 @@
       ]
     },
     {
-      "id": "darksky-datasource",
+      "id": "andig-darksky-datasource",
       "type": "datasource",
       "url": "https://github.com/andig/grafana-darksky",
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "4137049da4f2ef2f3f25143080330c530930f3f4",
+          "commit": "53dcda3a79c5a59b49c380c08a68e1730f92d4d9",
           "url": "https://github.com/andig/grafana-darksky"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2355,6 +2355,18 @@
           "url": "https://github.com/farshidtz/linksmart-sensorthings-datasource"
         }
       ]
+    },
+    {
+      "id": "darksky-datasource",
+      "type": "datasource",
+      "url": "https://github.com/andig/grafana-darksky",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "4137049da4f2ef2f3f25143080330c530930f3f4",
+          "url": "https://github.com/andig/grafana-darksky"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## DarkSky Datasource - weather and forecast data for Grafana

This plugin allows to history weather conditions and forecast data as returned by the [DarkSky](https://darksky.net) API.

![dashboard](https://raw.githubusercontent.com/andig/grafana-darksky/gh-pages/dashboard.png)

### Requirements

1. API key

   Register for a DarkSky API key at [DarkSky](https://darksky.net). The free plan will allow 1000 API calls per day.

2. Geo location

   Weather data will be available for the location defined when creating the data source. If unsure you can alwayds use [Google Maps](https://maps.google.com) or IP location APIs like [ipgeolocation.io](https://ipgeolocation.io).

### Configuration

Example configuration:

![config](https://raw.githubusercontent.com/andig/grafana-darksky/gh-pages/config.png)
