### PR TITLE
added consul-datasource plugin v0.1.5

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2355,6 +2355,18 @@
           "url": "https://github.com/farshidtz/linksmart-sensorthings-datasource"
         }
       ]
+    },
+    {
+      "id": "sbueringer-consul-datasource",
+      "type": "datasource",
+      "url": "https://github.com/sbueringer/grafana-consul-datasource",
+      "versions": [
+        {
+          "version": "0.1.5",
+          "commit": "60f73d5aef6a64068379e7625b99d0d8114b8ee1",
+          "url": "https://github.com/sbueringer/grafana-consul-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hi,

I'm not sure what an iditomatic plugin-id would be, so I just chose `consul-datasource`. Test environment should be more or less `npm run testcoverage` and `npm run go-testcoverage` (there is also a .travis.yml file).

Please let me now if I missed something ;)