### PR TITLE
add thruk datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1865,6 +1865,18 @@
       ]
     },
     {
+      "id": "sni-thruk-datasource",
+      "type": "datasource",
+      "url": "https://github.com/sni/grafana-thruk-datasource",
+      "versions": [
+        {
+          "version": "1.0.1",
+          "commit": "050d770946ad0f12750d206055b80d9389e9ea52",
+          "url": "https://github.com/sni/grafana-thruk-datasource"
+        }
+      ]
+    },
+    {
       "id": "digiapulssi-organisations-panel",
       "type": "panel",
       "url": "https://github.com/digiapulssi/grafana-organisations-panel",


### PR DESCRIPTION
This datasource supports thruks (https://thruk.org) rest api which allows
various table requests for nagios/naemon/icinga setups.

Currently it supports annotations to add log events like notifications to
existing graphs.

It supports variables to use hostnames/hostgroups and stuff like that in
existing dashboards.

It also supports table panel queries to show any data from the rest api which
includes alerts, current status and such things.

In order to test this datasource, you can use https://demo.thruk.org/thruk/ with basic
auth enabled using admin/admin credentials.