### PR TITLE
updating ambari metrics datasource to v1.2.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1028,6 +1028,11 @@
       "url": "https://github.com/prajwalrao/ambari-metrics-grafana",
       "versions": [
         {
+          "version": "1.2.0",
+          "commit": "d429f53128fc8db3be7f719f153d228b643189eb",
+          "url": "https://github.com/prajwalrao/ambari-metrics-grafana"
+        },
+        {
           "version": "1.0.1",
           "commit": "2feac1f964fd08c48f12d8973c5a9ae49e46d154",
           "url": "https://github.com/prajwalrao/ambari-metrics-grafana"


### PR DESCRIPTION
- Grafana > v4.5.x support added
- fixed [#8](https://github.com/prajwalrao/ambari-metrics-grafana/issues/8)
