### PR TITLE
Update repo.json to add scadavis-synoptic-panel

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2438,6 +2438,18 @@
           "url": "https://github.com/flant/grafana-statusmap"
         }
       ]
+    },
+    {
+      "id": "scadavis-synoptic-panel",
+      "type": "panel",
+      "url": "https://github.com/riclolsen/scadavis-synoptic-panel",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "aa5d44dc9c9ce4be4c65ec5578fd1989f4218b6c",
+          "url": "https://github.com/riclolsen/scadavis-synoptic-panel"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -2445,8 +2445,8 @@
       "url": "https://github.com/riclolsen/scadavis-synoptic-panel",
       "versions": [
         {
-          "version": "1.0.1",
-          "commit": "46950eed6cafd7b6220b0c13144b7fa79acf6b68",
+          "version": "1.0.2",
+          "commit": "9ad761917abff9ec43a2b90ad47939fbc16c5c01",
           "url": "https://github.com/riclolsen/scadavis-synoptic-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2445,8 +2445,8 @@
       "url": "https://github.com/riclolsen/scadavis-synoptic-panel",
       "versions": [
         {
-          "version": "1.0.0",
-          "commit": "aa5d44dc9c9ce4be4c65ec5578fd1989f4218b6c",
+          "version": "1.0.1",
+          "commit": "46950eed6cafd7b6220b0c13144b7fa79acf6b68",
           "url": "https://github.com/riclolsen/scadavis-synoptic-panel"
         }
       ]


### PR DESCRIPTION
Please review my plugin: scadavis-synoptic-panel.
A powerful SCADA-like synoptic graphics panel for Grafana.
Free-form vector graphics can be created in SVG format using an Inkscape based editor.