### PR TITLE
Add enhanced JSON datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2433,6 +2433,18 @@
       ]
     },
     {
+      "id": "grafana-json-datasource",
+      "type": "datasource",
+      "url": "https://github.com/simPod/grafana-json-datasource",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "commit": "8919f9b76e07fd6b7bf3f6c6b4682cb48bdeb77d",
+          "url": "https://github.com/simPod/grafana-json-datasource"
+        }
+      ]
+    },
+    {
       "id": "flant-statusmap-panel",
       "type": "panel",
       "url": "https://github.com/flant/grafana-statusmap",

--- a/repo.json
+++ b/repo.json
@@ -2433,13 +2433,13 @@
       ]
     },
     {
-      "id": "grafana-json-datasource",
+      "id": "simpod-json-datasource",
       "type": "datasource",
       "url": "https://github.com/simPod/grafana-json-datasource",
       "versions": [
         {
           "version": "0.1.0",
-          "commit": "8919f9b76e07fd6b7bf3f6c6b4682cb48bdeb77d",
+          "commit": "c2b80cf2e9d57060968e71b7b2001c7fc816b03f",
           "url": "https://github.com/simPod/grafana-json-datasource"
         }
       ]


### PR DESCRIPTION
This is a type-script written fork of the original SimpleJSON datasource. 

Most notably, it includes the ability to pass additional parameters as part of the `/query` request to allow differentiated responses by backend adapters:

<img width="1081" alt="screen shot 2018-10-23 at 19 50 01" src="https://user-images.githubusercontent.com/184815/47380123-01332880-d6fd-11e8-8e82-3e09379fd84d.png">

One example backend adapter is https://github.com/andig/gravo which accepts grafana json queries and extracts multiple metrics simultaneously from an underlying [volkszaehler](https://volkszaehler.org) REST api. Additional JSON parameters are used to provide fine-grained control on how to use the REST api (in the screenshot above by retrieving pre-aggregated data). In that respect it provides similar functionality, though with less abstraction due to its generic nature, as the Prometheus datasource.

Upstream PRs for https://github.com/grafana/simple-json-datasource/pull/100, https://github.com/grafana/simple-json-datasource/pull/103, https://github.com/grafana/simple-json-datasource/pull/104 have been applied.