### PR TITLE
Kentik v1.3.1 (and missing 1.3.0)

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1575,8 +1575,18 @@
     {
       "id": "kentik-app",
       "type": "app",
-      "url": "https://github.com/raintank/kentik-app",
+      "url": "https://github.com/grafana/kentik-app",
       "versions": [
+        {
+          "version": "1.3.1",
+          "commit": "072809a8b94c4b9d07b414899c9bb66b2f84cbf8",
+          "url": "https://github.com/grafana/kentik-app"
+        },
+        {
+          "version": "1.3.0",
+          "commit": "da775e38459e810ca790bcf009bc0f6062a0bdcb",
+          "url": "https://github.com/grafana/kentik-app"
+        },
         {
           "version": "1.2.4",
           "commit": "db58410e71a109077436fa20d0a0d515d9d9af76",


### PR DESCRIPTION
Kentik release v1.3.1. Since plugin was moved from `raintank` org into `grafana`, URL was changed. Also, added missing 1.3.0 version.