### PR TITLE
add grafana-polystat-panel

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2530,7 +2530,7 @@
       "versions": [
         {
           "version": "1.0.14",
-          "commit": "280e5985e1aed5d66d4282e4ae8b97b4bfd5c133",
+          "commit": "71ee146d6849e6546bde3da084686d168006042a",
           "url": "https://github.com/grafana/grafana-polystat-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2522,6 +2522,18 @@
           "url": "https://github.com/sbueringer/grafana-consul-datasource"
         }
       ]
+    },
+    {
+      "id": "grafana-polystat-panel",
+      "type": "panel",
+      "url": "https://github.com/grafana/grafana-polystat-panel",
+      "versions": [
+        {
+          "version": "1.0.14",
+          "commit": "280e5985e1aed5d66d4282e4ae8b97b4bfd5c133",
+          "url": "https://github.com/grafana/grafana-polystat-panel"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
First public release of polystat (honeycomb) panel.

Source and docs are at: https://github.com/grafana/grafana-polystat-panel

`docker-compose.yml` provided for quick setup.