### PR TITLE
flant-statusmap-panel v0.0.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2498,13 +2498,8 @@
       "url": "https://github.com/flant/grafana-statusmap",
       "versions": [
         {
-          "version": "0.0.1",
-          "commit": "cf31fded9d3cd43ab63092064beef4a45123cf69",
-          "url": "https://github.com/flant/grafana-statusmap"
-        },
-        {
-          "version": "0.0.2",
-          "commit": "bccc3320a8be7cb764bfaff0515af8fd348e0b54",
+          "version": "0.0.3",
+          "commit": "cb5d353b36c6a8b264bdaeca4f594b51abaa8afe",
           "url": "https://github.com/flant/grafana-statusmap"
         }
       ]


### PR DESCRIPTION
- remove all button for discrete color mode
- solarized preset for discrete color mode
- fix display null values as zero
- separate vertical and horizontal spacing for cards
- three sort modes for y axis labels
