### PR TITLE
Update flant-statusmap-panel version to 0.0.4

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2525,8 +2525,8 @@
       "url": "https://github.com/flant/grafana-statusmap",
       "versions": [
         {
-          "version": "0.0.3",
-          "commit": "cb5d353b36c6a8b264bdaeca4f594b51abaa8afe",
+          "version": "0.0.4",
+          "commit": "e1abad408e71cef5b92ef9ab5fbc0bd0503cd22e",
           "url": "https://github.com/flant/grafana-statusmap"
         }
       ]


### PR DESCRIPTION
A hotfix for a bug introduced in 0.0.3 version.

- Fix display of multivalues buckets as an empty cell
