### PR TITLE
Update marcuscalidus-svg-panel V0.3.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2265,6 +2265,11 @@
           "version": "0.2.0",
           "commit": "a35d183f92e9ac0509c59d592ee724b8190ccb72",
           "url": "https://github.com/MarcusCalidus/marcuscalidus-svg-panel"
+        },
+        {
+          "version": "0.3.0",
+          "commit": "5f5b2bd541fb1e3c348dd8df301a76a13be5dc76",
+          "url": "https://github.com/MarcusCalidus/marcuscalidus-svg-panel"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2268,7 +2268,7 @@
         },
         {
           "version": "0.3.0",
-          "commit": "5f5b2bd541fb1e3c348dd8df301a76a13be5dc76",
+          "commit": "56d2a0fb2b25f36bf55cfa24baae0fa8c5636dea",
           "url": "https://github.com/MarcusCalidus/marcuscalidus-svg-panel"
         }
       ]


### PR DESCRIPTION
Update to Version 0.3.0 of marcuscalidus-svg-panel.
Support for "docs" type of input data. (e.g. Elasticsearch Raw Documents)