### PR TITLE
Added MyMight IoT datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -546,6 +546,18 @@
       ]
     },
     {
+      "id": "mymight-datasource",
+      "type": "datasource",
+      "url": "https://github.com/vjindra-mymight/mymightdatasource/",
+      "versions": [
+	{
+          "version": "7.0",
+          "commit": "47a2ff6440d7ee66a0c2cf9939f49d3cfa2753d6",
+          "url": "https://github.com/vjindra-mymight/mymightdatasource/"
+        }
+      ]
+    },
+    {
       "id": "grafana-kairosdb-datasource",
       "type": "datasource",
       "url": "https://github.com/grafana/kairosdb-datasource",


### PR DESCRIPTION
## MyMight IoT

MyMight IoT datasource allows you to query and visualize data obtained from the MyMight IoT.

MyMight IoT documentation can be found at the [MyMight API](https://api.mymight.com/) website.

### Adding the datasource

1. Open the side menu by clicking the Grafana icon in the top header.
2. In the side menu hover over the Configuration icon and click on the Data Sources.
3. Click the Add data source button in the top header.
4. Select MyMight IoT from the type dropdown.
5. Fill in your server's URL (e.g. `https://demo.mymight.com/sense/rest/client`).
6. In the Auth section select the TLS Client Auth option.
7. Paste your Client Cert and Client Key in the corresponding fields.
8. Fill in your Project ID.
9. Click Save & Test button.