### PR TITLE
Update gridprotectionalliance-osisoftpi-datasource to version 1.0.4

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1122,6 +1122,11 @@
           "version": "1.0.3",
           "commit": "cf1d6c4a2a4a11682cbb61c0c0c4951cbffd72a0",
           "url": "https://github.com/GridProtectionAlliance/osisoftpi-grafana"
+        },
+        {
+          "version": "1.0.4",
+          "commit": "095993cd42cd81d562cd635569392592864872d1",
+          "url": "https://github.com/GridProtectionAlliance/osisoftpi-grafana"
         }
       ]
     },


### PR DESCRIPTION
Update gridprotectionalliance-osisoftpi-datasource to version 1.0.4. This release includes several PR fixes below. It also updates any npm dependencies.

- Ability to use template variables in calculations
- Fix Streamset URL
- Fix CRSF for PI WebAPI 201
- Give preference to Display Name