### PR TITLE
Update clickhouse-grafana to 1.8.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1837,6 +1837,11 @@
           "version": "1.7.0",
           "commit": "811147bd6f8f4c63c81350021071ac42558761fa",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "1.8.0",
+          "commit": "0ce7f18e474ae19ee368e9d7bea21dd843e45bfc",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -1887,6 +1887,11 @@
           "version": "1.8.0",
           "commit": "0ce7f18e474ae19ee368e9d7bea21dd843e45bfc",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "1.8.1",
+          "commit": "bcc1877634476b84c2f7266d05824214415adfd6",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },


### PR DESCRIPTION
Please, see release updates https://github.com/Vertamedia/clickhouse-grafana/releases/tag/1.8.1

New features:
* Add `timeFilterByColumn` macro 

Fixes:
* add requestId to queries so that abandoned one are cancelled 
* bug with parentheses in `$unescape` macros
* bug with treating string as numbers in table view

cc @nvartolomei

