### PR TITLE
Update fetzerch-sunandmoon-datasource plugin (v0.1.3)

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1036,6 +1036,11 @@
       "url": "https://github.com/fetzerch/grafana-sunandmoon-datasource",
       "versions": [
         {
+          "version": "0.1.3",
+          "commit": "d632d56484c467931678f4754d851efdb208e0fd",
+          "url": "https://github.com/fetzerch/grafana-sunandmoon-datasource"
+        },
+        {
           "version": "0.1.2",
           "commit": "d5bc5ee7e21c32dcdd6d8c9c2b9db96522f85f9c",
           "url": "https://github.com/fetzerch/grafana-sunandmoon-datasource"


### PR DESCRIPTION
- Update SunCalc dependency to 1.8.0. (fixes https://github.com/fetzerch/grafana-sunandmoon-datasource/issues/8)
- Update other dependencies to the latest versions.
