### PR TITLE
Update 'pr0ps-trackmap-panel' to v2.0.4

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2826,6 +2826,11 @@
           "version": "2.0.3",
           "commit": "a6a591ca5af416de849b77f22ca90c5fe5de49e6",
           "url": "https://github.com/pR0Ps/grafana-trackmap-panel"
+        },
+        {
+          "version": "2.0.4",
+          "commit": "8118701b5d3b136de1bf1ae6b27aa1f0b589da8c",
+          "url": "https://github.com/pR0Ps/grafana-trackmap-panel"
         }
       ]
     }


### PR DESCRIPTION
- Fixes some issues with Grafana v6 (panel not rendering and not updating when resized)
- Fixes an issue with the icon not being rendered properly
- Adds support for snapshots