### PR TITLE
add ilgizar-candlestick-panel to plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2828,6 +2828,18 @@
           "url": "https://github.com/pR0Ps/grafana-trackmap-panel"
         }
       ]
+    },
+    {
+      "id": "ilgizar-candlestick-panel",
+      "type": "panel",
+      "url": "https://github.com/ilgizar/ilgizar-candlestick-panel",
+      "versions": [
+        {
+          "version": "0.0.1",
+          "commit": "1944a532f6891659fbf94ae8b42571a481187b85",
+          "url": "https://github.com/ilgizar/ilgizar-candlestick-panel"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Read the [Review Guidelines](http://docs.grafana.org/plugins/developing/plugin-review-guidelines/) before submitting your plugin. These guidelines determine if the plugin is ready to be published or not.

- Commercial plugins require a plugin subscription to be published. Commercial plugin subscriptions help us fund continued development of our open source platform and software. See the [terms](https://grafana.com/terms) for more details.

- If possible, for datasource plugins please provide a description on how to set up a simple test environment. A docker container or simple install script helps speed up the review process a lot.

**REMOVE THE TEXT ABOVE BEFORE CREATING THE PULL REQUEST**