### PR TITLE
Update flant-statusmap-panel version to 0.1.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2679,6 +2679,12 @@
           "version": "0.0.4",
           "commit": "e1abad408e71cef5b92ef9ab5fbc0bd0503cd22e",
           "url": "https://github.com/flant/grafana-statusmap"
+        },
+        {
+
+          "version": "0.1.0",
+          "commit": "624be3450dc3025929a1bf0d2f745bbbb393b6b1",
+          "url": "https://github.com/flant/grafana-statusmap"
         }
       ]
     },


### PR DESCRIPTION
- Tested with Grafana 6.0.0
- Tested with InfluxDB and Mysql datasources
- Add initial support for display annotations
- Add example for k8s statuses (thanks, @vrutkovs)
- Fix hanging on big values
- Fix horizontal spacing = 0
- Fix for "Object doesn't support property or method 'remove'"
- Fix card width for targets with different datapoints count
