### PR TITLE
update grafana-polystat-panel

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2624,6 +2624,11 @@
           "version": "1.0.15",
           "commit": "9475cd358e7149882564a03e4b15562842e81246",
           "url": "https://github.com/grafana/grafana-polystat-panel"
+        },
+        {
+          "version": "1.0.16",
+          "commit": "a1347fb4639829e318fb7f2e69a6985f3dbc4ffc",
+          "url": "https://github.com/grafana/grafana-polystat-panel"
         }
       ]
     },


### PR DESCRIPTION
Updates grafana-polystat-panel to v1.0.16

* fixes variable encoding in clickthrough urls