### PR TITLE
Update repo.json - adding minor revision (bug fix) for MultiStat

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2770,6 +2770,11 @@
           "version": "1.2.0",
           "commit": "f514b203f40187000a134cce5696a85a8ae0c72a",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.1",
+          "commit": "1ae5a949e27b1babf111b6f7018f07cbd4d5f603",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"          
         }
       ]
     },


### PR DESCRIPTION
Multistat version 1.2.0 worked with the beta release of Grafana 6, but apparently has a problem with the official release (6.0.2).  The problem was related to this.ctrl.height being undefined after the dashboard first loads.

I have a fix in in this version (michaeldmoore.multistat.panel version 1.2.1) which seems to work in all cases.

Please update the official repository to publish this fixed version.

Michael Moore