### PR TITLE
Update Multistat to version 1.2.2 with bug fix to correct group/value sorting bug

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2814,7 +2814,7 @@
         },
         {
           "version": "1.2.2",
-          "commit": "2272fc4519f753aa523679aab24c37cfee137fba",
+          "commit": "ea58834449f7ac206fff856d05c96bc0e7238c16",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2811,6 +2811,11 @@
           "version": "1.2.1",
           "commit": "1ae5a949e27b1babf111b6f7018f07cbd4d5f603",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.2",
+          "commit": "2272fc4519f753aa523679aab24c37cfee137fba",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]
     },


### PR DESCRIPTION
Previously, only non-grouped panels would sort on value.  This version provides a fix