### PR TITLE
Adding Scrutinizer Datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3065,6 +3065,7 @@
           "commit":"452f8d1ea986e7de1bbb1dc54f1bf8ccd49dc62c",
           "url": "https://github.com/plixer/scrutinizer-datasource"
         }
+      ]
     },
        {
       "id": "doitintl-bigquery-datasource",

--- a/repo.json
+++ b/repo.json
@@ -2946,6 +2946,18 @@
           "url": "https://github.com/cognitedata/cognite-grafana-datasource"
         }
       ]
+    },
+     {
+      "id": "scrutinizer-datasource",
+      "type":"datasource",
+      "url": "https://github.com/plixer/scrutinizer-datasource",
+      "versions":[
+        {
+          "version":"1.0.0",
+          "commit":"452f8d1ea986e7de1bbb1dc54f1bf8ccd49dc62c",
+          "url": "https://github.com/plixer/scrutinizer-datasource"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -3066,7 +3066,7 @@
           "url": "https://github.com/plixer/scrutinizer-datasource"
         }
     },
-
+       {
       "id": "doitintl-bigquery-datasource",
       "type": "datasource",
       "url": "https://github.com/doitintl/bigquery-grafana",


### PR DESCRIPTION
Plixer manufacturers a metadata collection and analysis solution called Scrutinizer. I would like to add a Scrutinizer Datasource to your supported plugins. 
**REMOVE THE TEXT ABOVE BEFORE CREATING THE PULL REQUEST**