### PR TITLE
Update Annunciator to version 1.0.2 with bug fix needed for Grafana 6.1+

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2235,7 +2235,7 @@
         },
         {
           "version": "1.0.2",
-          "commit": "d66ed275eb9193a341612baa873cf1fc1a587e1e",
+          "commit": "dfc33b15a6f3663be7b840197b22b3c2865c9ae5",
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
         }	      
       ]

--- a/repo.json
+++ b/repo.json
@@ -2232,7 +2232,12 @@
           "version": "1.0.0",
           "commit": "542707e504b1461bb6fb70b86c8a637f93724181",
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
-        }
+        },
+        {
+          "version": "1.0.2",
+          "commit": "64052dec1f0efd679d65cdfe4cae15523dba4b10",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+        }	      
       ]
     },
     {

--- a/repo.json
+++ b/repo.json
@@ -2235,7 +2235,7 @@
         },
         {
           "version": "1.0.2",
-          "commit": "64052dec1f0efd679d65cdfe4cae15523dba4b10",
+          "commit": "d66ed275eb9193a341612baa873cf1fc1a587e1e",
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
         }	      
       ]


### PR DESCRIPTION
Grafana 6.1+ changed the initial call to render() leaving the panel.ctrl.height value undefined.  This minor bug fix to annunciator works around this issue.

The gruntfile is also enhanced to support jshint checking.