### PR TITLE
upgrade `goshposh-metaqueries-datasource` to `0.0.2`

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2685,7 +2685,7 @@
       "versions": [
         {
           "version": "0.0.2",
-          "commit": "08b896c443b04b8df4bf2e76bec44ff2a852850c",
+          "commit": "34e0837fb9fc24e0f8a4865a20d7bd7ee19da32e",
           "url": "https://github.com/GoshPosh/grafana-meta-queries"
         },
         {

--- a/repo.json
+++ b/repo.json
@@ -2684,6 +2684,11 @@
       "url": "https://github.com/GoshPosh/grafana-meta-queries",
       "versions": [
         {
+          "version": "0.0.2",
+          "commit": "08b896c443b04b8df4bf2e76bec44ff2a852850c",
+          "url": "https://github.com/GoshPosh/grafana-meta-queries"
+        },
+        {
           "version": "0.0.1",
           "commit": "476f41125af094cd63034e4b8bbaf8007bf82211",
           "url": "https://github.com/GoshPosh/grafana-meta-queries"


### PR DESCRIPTION
Upgrading the datasource plugin version.
* added support for nested metaqueries
* fixed hiddenQueries for grafana 6.2+
* added support for minInterval