### PR TITLE
Update corpglory-progresslist-panel to 1.0.4

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2398,6 +2398,11 @@
           "version": "0.1.1",
           "commit": "cd4f1b1cbe6eb1f1ebad4d3d0df45c58c29ae866",
           "url": "https://github.com/CorpGlory/grafana-progress-list"
+        },
+        {
+          "version": "1.0.4",
+          "commit": "5b46bfb30c3de7c14b72d8f5fb0b50f6790a78e0",
+          "url": "https://github.com/CorpGlory/grafana-progress-list"
         }
       ]
     },


### PR DESCRIPTION
## Changes
- Support alias for keys
- Support Grafana behind sub-url (e.g. `http://localhost:3000/grafana`)