### PR TITLE
Add QuasarDB Grafana Datasource Plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3155,6 +3155,18 @@
           "url": "https://github.com/paytm/kapacitor-grafana-datasource-plugin"
         }
       ]
+    },
+    {
+      "id": "quasardb-datasource",
+      "type": "datasource",
+      "url": "https://github.com/bureau14/qdb-grafana-plugin",
+      "versions": [
+        {
+          "version": "3.4.0",
+          "commit": "c09ae27da40afde326711e615ef5648bda427571",
+          "url": "https://github.com/bureau14/qdb-grafana-plugin"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# QuasarDB Datasource

QuasarDB runs in insecure mode which allows for anonymous login, and secure mode which requires a username and secret key.

## Setting up

Please note this is just for demonstration purposes and not the recommended way to set up QuasarDB

A complete environment can be build with docker using the following command.

```
docker build -t qdb-grafana-example-docker https://github.com/kontrarian/qdb-grafana-example-docker.git
```

The updated `dist/` folder is included in the plugin git repository so it can be cloned directory to the grafana plugins directory to install it.

## Testing Anonymous Login

```
docker run -it -p 40080:40080 qdb-grafana-example-docker
```

This will start the QuasarDB db server and rest server in the background, log you into bash and print the server url to the console.

In the plugin configuration set the `URL` to `http://127.0.0.1:40080` and the `Access` to `Server`. Auth can be skipped and toggle off `Use Secured Cluster` under QuasarDB Details

## Testing Secure Login

```
docker run -it -p 40493:40493 --env QDB_SECURITY=true qdb-grafana-example-docker
```

This will start the QuasarDB db server and rest server in the background, log you into bash and print the server url and user credentials to the console.

In the plugin configuration set the `URL` to `https://127.0.0.1:40493` and the `Access` to `Server`. Under Auth ensure `Skip TLS Verify` is checked as this demo uses self-signed TLS certificates. Under QuasarDB Details toggle on `User Secured Cluster` and enter the `User name` and `User secret` that were printed to the console when you ran the docker container.

Please ping me if there is anything you need.

Kind regards,
Mike