### PR TITLE
BigQuery Datasource Version 1.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3108,6 +3108,11 @@
           "version": "0.6.1",
           "commit": "d4f7611a15b86ddbb355fe5f1f3ad9753ac2e6fe",
           "url": "https://github.com/doitintl/bigquery-grafana"
+        },
+        {
+          "version": "1.0.0",
+          "commit": "d0998daebf8acac79388d9d4acdbf22ef966f2a4",
+          "url": "https://github.com/doitintl/bigquery-grafana"
         }
       ]
     }


### PR DESCRIPTION
We are out of Beta. First production-ready version
@daniellee if you can merge this today (25/6) before the Grafana blog post will come it will be great!
Thanks
