### PR TITLE
Added linksmart-hds-datasource v1.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2774,6 +2774,18 @@
       ]
     },
     {
+      "id": "linksmart-hds-datasource",
+      "type": "datasource",
+      "url": "https://github.com/linksmart/grafana-hds-datasource",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "9cb2c740e78d1b09b7e920271689281fd52916f7",
+          "url": "https://github.com/linksmart/grafana-hds-datasource"
+        }
+      ]
+    },
+    {
       "id": "andig-darksky-datasource",
       "type": "datasource",
       "url": "https://github.com/andig/grafana-darksky",


### PR DESCRIPTION
Hi,

I would like to submit this plugin to visualize Sensor data (in [SenML](https://tools.ietf.org/html/rfc8428) format) stored in open source [Historical Datastore](https://github.com/linksmart/historical-datastore). 

This plugin can be tested with a fake HDS server (with continuously growing dummy senML data) by running following command:
```
docker run -p 8085:8085  linksmart/hds -demo -conf /conf/docker.json
```

Thank you.