### PR TITLE
Add griddb datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3137,6 +3137,18 @@
           "url": "https://github.com/doitintl/bigquery-grafana"
         }
       ]
+    },
+    {
+      "id": "griddb-datasource",
+      "type": "datasource",
+      "url": "https://github.com/griddb/griddb-datasource",
+      "versions": [
+        {
+          "version": "1.1.0",
+          "commit": "d88be040383396c1e075ef43190c81a3a1c227f6",
+          "url": "https://github.com/griddb/griddb-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
GridDB (https://github.com/griddb/griddb_nosql) is a highly scalable NoSQL database best suited for IoT and Big Data.

[GridDB datasource plugin](https://github.com/griddb/griddb-datasource) is used to get data from GridDB and display as graph or table base on [Grafana](https://github.com/grafana/grafana).

Could you please review this ?

Note: GridDB Website: https://griddb.net/