### PR TITLE
zabbix plugin v3.10.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -336,6 +336,11 @@
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
         {
+          "version": "3.10.3",
+          "commit": "362e0a78b590ba68f1bfd3d8c735d93ce318b1a8",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix"
+        },
+        {
           "version": "3.10.2",
           "commit": "9007e236108713a0efcc8f5d9004ada9ef51de19",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix"


### PR DESCRIPTION
Zabbix plugin update v3.10.3

## [3.10.3] - 2019-07-26
### Fixed
- Direct DB Connection: can't stay enabled, [#731](https://github.com/alexanderzobnin/grafana-zabbix/issues/731)
- Triggers query mode: count doesn't work with Singlestat, [#726](https://github.com/alexanderzobnin/grafana-zabbix/issues/726)
- Query editor: function editor looks odd in Grafana 6.x, [#765](https://github.com/alexanderzobnin/grafana-zabbix/issues/765)
- Alerting: heart icon on panels in Grafana 6.x, [#715](https://github.com/alexanderzobnin/grafana-zabbix/issues/715)
