### PR TITLE
Update linksmart-sensorthings-datasource to v1.3.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2594,8 +2594,8 @@
       "url": "https://github.com/farshidtz/linksmart-sensorthings-datasource",
       "versions": [
         {
-          "version": "1.1.0",
-          "commit": "17ac9f02461204c126a8cd2ccd85d964e1625fab",
+          "version": "1.2.0",
+          "commit": "7d591da79a2efc6c610ce88ad3e337fd80724e4d",
           "url": "https://github.com/farshidtz/linksmart-sensorthings-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2775,12 +2775,12 @@
     {
       "id": "linksmart-sensorthings-datasource",
       "type": "datasource",
-      "url": "https://github.com/farshidtz/linksmart-sensorthings-datasource",
+      "url": "https://github.com/linksmart/grafana-sensorthings-datasource",
       "versions": [
         {
-          "version": "1.2.0",
-          "commit": "7d591da79a2efc6c610ce88ad3e337fd80724e4d",
-          "url": "https://github.com/farshidtz/linksmart-sensorthings-datasource"
+          "version": "1.3.0",
+          "commit": "a5412a339b7326c46ef3e8f5b376d576ed3fcb8f",
+          "url": "https://github.com/linksmart/grafana-sensorthings-datasource"
         }
       ]
     },


### PR DESCRIPTION
Hi,

I would like to submit an update for [SensorThings](https://grafana.com/plugins/linksmart-sensorthings-datasource) plugin. It extends support for Feature-type GeoJSON and updates some package links. Changelog is [here](https://github.com/linksmart/grafana-sensorthings-datasource/blob/master/CHANGELOG.md).

Instructions to start a SensorThings server with dummy data to test the plugin: https://github.com/linksmart/sensorthings-faker

Looking forward to the merge.
Thanks!