### PR TITLE
Add rockset datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3189,7 +3189,7 @@
       "url": "https://github.com/rockset/rockset-grafana",
       "versions": [
         {
-          "version": "1.0.1",
+          "version": "1.0.3",
           "commit": "23e871babf84ecdeab08d23cca8c52d29abf5f7d",
           "url": "https://github.com/rockset/rockset-grafana"
         }

--- a/repo.json
+++ b/repo.json
@@ -3189,8 +3189,8 @@
       "url": "https://github.com/rockset/rockset-grafana",
       "versions": [
         {
-          "version": "1.0.3",
-          "commit": "3d6e5a13ef8b227a2ea0187c811d8e7dc7be1630",
+          "version": "1.0.4",
+          "commit": "5756b415325ff2798b1ef6cd8b8bc3ec969bef70",
           "url": "https://github.com/rockset/rockset-grafana"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3182,6 +3182,18 @@
           "url": "https://github.com/bureau14/qdb-grafana-plugin"
         }
       ]
+    },
+    {
+      "id": "rockset-grafana",
+      "type": "datasource",
+      "url": "https://github.com/rockset/rockset-grafana",
+      "versions": [
+        {
+          "version": "1.0.1",
+          "commit": "23e871babf84ecdeab08d23cca8c52d29abf5f7d",
+          "url": "https://github.com/rockset/rockset-grafana"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -3184,13 +3184,13 @@
       ]
     },
     {
-      "id": "rockset-grafana",
+      "id": "rockset-rockset-datasource",
       "type": "datasource",
       "url": "https://github.com/rockset/rockset-grafana",
       "versions": [
         {
           "version": "1.0.3",
-          "commit": "23e871babf84ecdeab08d23cca8c52d29abf5f7d",
+          "commit": "b48189f861dc121ed33816f6a6a7ee4cfb95d727",
           "url": "https://github.com/rockset/rockset-grafana"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3190,7 +3190,7 @@
       "versions": [
         {
           "version": "1.0.3",
-          "commit": "b48189f861dc121ed33816f6a6a7ee4cfb95d727",
+          "commit": "3d6e5a13ef8b227a2ea0187c811d8e7dc7be1630",
           "url": "https://github.com/rockset/rockset-grafana"
         }
       ]


### PR DESCRIPTION
Added rockset datasource to grafana. Full documentation is available at https://github.com/rockset/rockset-grafana, or the docs page at https://docs.rockset.com/grafana/