### PR TITLE
upgrade `goshposh-metaqueries-datasource` to `0.0.3`

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2730,6 +2730,11 @@
       "url": "https://github.com/GoshPosh/grafana-meta-queries",
       "versions": [
         {
+          "version": "0.0.3",
+          "commit": "cae59ffef31ca83fa0973c04ecec5d4420ba6205",
+          "url": "https://github.com/GoshPosh/grafana-meta-queries"
+        },
+        {
           "version": "0.0.2",
           "commit": "34e0837fb9fc24e0f8a4865a20d7bd7ee19da32e",
           "url": "https://github.com/GoshPosh/grafana-meta-queries"


### PR DESCRIPTION
added support for grafana 6.3 as `ds.name` is removed in commit : https://github.com/grafana/grafana/commit/1d7bb2a#diff-894468679ebfe67fc2c22f7575f9e2c2