### PR TITLE
Release grafana-image-renderer v1.0.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3246,6 +3246,25 @@
               "md5": "842d6c998840abe4b9608c0d5c86af59"
             }
           }
+        },
+        {
+          "version": "1.0.3",
+          "commit": "9f845e080d1525e26818d93e000ee160618f1eec",
+          "url": "https://github.com/grafana/grafana-image-renderer",
+          "download": {
+            "darwin-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.3/plugin-darwin-x64-unknown.zip",
+              "md5": "329d4d5020f8e626d3661d1aae21d810"
+            },
+            "linux-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.3/plugin-linux-x64-glibc.zip",
+              "md5": "6f36cffad5b55e339ba29ae1ec369abf"
+            },
+            "windows-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.3/plugin-win32-x64-unknown.zip",
+              "md5": "d1f7c0a407eeb198d82358a94d884778"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
https://github.com/grafana/grafana-image-renderer/releases/tag/v1.0.3