### PR TITLE
updated Alexandra-track-map to v.1.2.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3274,8 +3274,8 @@
       "url": "https://github.com/alexandrainst/alexandra-trackmap-panel",
       "versions": [
         {
-          "version": "1.1.1",
-          "commit": "e1ed0c4368880c2522bb639f82a88c99d1f0d3f5",
+          "version": "1.2.0",
+          "commit": "b383485053bcedcf18ab75be1b04a995e7b9c464",
           "url": "https://github.com/alexandrainst/alexandra-trackmap-panel"
         }
       ]


### PR DESCRIPTION
Updated the alexandra-track-map panel to version 1.2.0
This update allow the use of the maps bounding box to be used in the query.