### PR TITLE
Multistat update to 1.2.4 - fix for grafana 6.4.x table data response error.

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2994,6 +2994,11 @@
           "version": "1.2.3",
           "commit": "0f4f9a6648ddbf6ac761359ea8bc9893aaed9038",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.4",
+          "commit": "314dea6894a3d3565e71fc06453811525b2258a6",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]
     },


### PR DESCRIPTION
Grafana 6.4.0 update introduced a bug which removed the type='table' value for non-timeseries data queries.  Multistat, which only works with table-formatted data relied on this property.  This minor version release adds an alternative method of determining the query type (namely the existence of a columns property which only table-formatted queries produce.
