### PR TITLE
Update clickhouse-grafana to 1.9.2

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2025,11 +2025,6 @@
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
         },
         {
-          "version": "1.9.2",
-          "commit": "582306a3e5e294a56e665f1e7a04692c47ecd8ed",
-          "url": "https://github.com/Vertamedia/clickhouse-grafana"
-        },
-        {
           "version": "1.9.3",
           "commit": "995b21bea651d2afbe8eea33b38dbe457349931d",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"

--- a/repo.json
+++ b/repo.json
@@ -2028,6 +2028,11 @@
           "version": "1.9.2",
           "commit": "582306a3e5e294a56e665f1e7a04692c47ecd8ed",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "1.9.3",
+          "commit": "995b21bea651d2afbe8eea33b38dbe457349931d",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2018,6 +2018,11 @@
           "version": "1.9.0",
           "commit": "cbbe244dc52f531db31497566342fa4bf4957975",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "1.9.2",
+          "commit": "582306a3e5e294a56e665f1e7a04692c47ecd8ed",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },


### PR DESCRIPTION
Please, see release updates https://github.com/Vertamedia/clickhouse-grafana/releases/tag/1.9.2

## Fixes:
* Compatibility fix to support grafana 6.4.x
* Ad Hoc Filters fix
* $conditionalTest ALL value option fix