### PR TITLE
add spotify's heroic datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -836,6 +836,18 @@
       ]
     },
     {
+      "id": "heroic-grafana-datasource",
+      "type": "datasource",
+      "url": "https://github.com/spotify/heroic-grafana-datasource",
+      "versions": [
+        {
+          "version": "0.0.1",
+          "commit": "62b7240c35f7d0a45cd036641ffb3c4bf854aa87",
+          "url": "https://github.com/spotify/heroic-grafana-datasource"
+        }
+      ]
+    },
+    {
       "id": "udoprog-heroic-datasource",
       "type": "datasource",
       "url": "https://github.com/udoprog/udoprog-heroic-datasource",

--- a/repo.json
+++ b/repo.json
@@ -3360,6 +3360,11 @@
           "version": "3.4.0",
           "commit": "c09ae27da40afde326711e615ef5648bda427571",
           "url": "https://github.com/bureau14/qdb-grafana-plugin"
+        },
+        {
+          "version": "3.5.0",
+          "commit": "28b492ccbbda8e6bccd51465a0f22b4cd4b216d6",
+          "url": "https://github.com/bureau14/qdb-grafana-plugin"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2927,6 +2927,11 @@
           "version": "0.1.4",
           "commit": "e89fb601321f990500320a1937a5a590bdd8fd1e",
           "url": "https://github.com/simPod/grafana-json-datasource"
+        },
+        {
+          "version": "0.1.5",
+          "commit": "bf9fc6bced0f28e44860da8e93b12d39879b6bd8",
+          "url": "https://github.com/simPod/grafana-json-datasource"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3365,6 +3365,25 @@
               "md5": "e3381cb73b0c780cc6db2b9b9575ae50"
             }
           }
+        },
+        {
+          "version": "1.0.6",
+          "commit": "7c21ce629e6df0dae7986110510b329be031e99f",
+          "url": "https://github.com/grafana/grafana-image-renderer",
+          "download": {
+            "darwin-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.6/plugin-darwin-x64-unknown.zip",
+              "md5": "a371520e418d05c5a6cd20880cff38a9"
+            },
+            "linux-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.6/plugin-linux-x64-glibc.zip",
+              "md5": "3cf1e855817596be8399eea1338b6502"
+            },
+            "windows-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.6/plugin-win32-x64-unknown.zip",
+              "md5": "d64f305f9dbedabdce9c29cff1761a58"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -848,13 +848,13 @@
       ]
     },
     {
-      "id": "heroic-grafana-datasource",
+      "id": "spotify-heroic-datasource",
       "type": "datasource",
       "url": "https://github.com/spotify/heroic-grafana-datasource",
       "versions": [
         {
           "version": "0.0.1",
-          "commit": "afb9853e41e81a906b543680603aaabe11a0e557",
+          "commit": "fb557abb3b8c411000400c5aff9ec0d7423fdd32",
           "url": "https://github.com/spotify/heroic-grafana-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3399,6 +3399,25 @@
               "md5": "d64f305f9dbedabdce9c29cff1761a58"
             }
           }
+        },
+        {
+          "version": "1.0.7",
+          "commit": "622fe88a1811645abf0441a1c038ea0c234c275f",
+          "url": "https://github.com/grafana/grafana-image-renderer",
+          "download": {
+            "darwin-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.7/plugin-darwin-x64-unknown.zip",
+              "md5": "be522b289c6d9969a4b4beb8cb098061"
+            },
+            "linux-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.7/plugin-linux-x64-glibc.zip",
+              "md5": "6328b53d48f44ae81ab383b6014830c9"
+            },
+            "windows-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.7/plugin-win32-x64-unknown.zip",
+              "md5": "8d9a5112bbc5cadeb4686e91fc858258"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2932,6 +2932,11 @@
           "version": "0.1.5",
           "commit": "bf9fc6bced0f28e44860da8e93b12d39879b6bd8",
           "url": "https://github.com/simPod/grafana-json-datasource"
+        },
+        {
+          "version": "0.1.6",
+          "commit": "60305041ed26a73f46c6b581b3bb28aa07a75201",
+          "url": "https://github.com/simPod/grafana-json-datasource"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2118,6 +2118,11 @@
       "url": "https://github.com/digiapulssi/grafana-organisations-panel",
       "versions": [
         {
+          "version": "1.2.0",
+          "commit": "869b8c66a9ecb0c4193cfe523daebadd6b3c7051",
+          "url": "https://github.com/digiapulssi/grafana-organisations-panel"
+        },
+        {
           "version": "1.1.0",
           "commit": "7125b2d3be2db83f894b8012397dccdd847720c9",
           "url": "https://github.com/digiapulssi/grafana-organisations-panel"

--- a/repo.json
+++ b/repo.json
@@ -2503,6 +2503,11 @@
           "version": "0.3.0",
           "commit": "56d2a0fb2b25f36bf55cfa24baae0fa8c5636dea",
           "url": "https://github.com/MarcusCalidus/marcuscalidus-svg-panel"
+        },
+        {
+          "version": "0.3.3",
+          "commit": "c1240ea7216bd820567750eb92d0be43dae3caae",
+          "url": "https://github.com/MarcusCalidus/marcuscalidus-svg-panel"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -854,7 +854,7 @@
       "versions": [
         {
           "version": "0.0.1",
-          "commit": "ae86e1ae9fc4f4d550e3ee9357d3ec9d34554270",
+          "commit": "afb9853e41e81a906b543680603aaabe11a0e557",
           "url": "https://github.com/spotify/heroic-grafana-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3483,6 +3483,18 @@
           "url": "https://github.com/rockset/rockset-grafana"
         }
       ]
+    },
+    {
+      "id": "jeanbaptistewatenberg-percent-panel",
+      "type": "panel",
+      "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus",
+      "versions": [
+        {
+          "version": "1.0.6",
+          "commit": "9e2785ea49c3f28092853a095d21400b50bd8280",
+          "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -854,7 +854,7 @@
       "versions": [
         {
           "version": "0.0.1",
-          "commit": "62b7240c35f7d0a45cd036641ffb3c4bf854aa87",
+          "commit": "ae86e1ae9fc4f4d550e3ee9357d3ec9d34554270",
           "url": "https://github.com/spotify/heroic-grafana-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -842,7 +842,7 @@
       "versions": [
         {
           "version": "0.0.1",
-          "commit": "62b7240c35f7d0a45cd036641ffb3c4bf854aa87",
+          "commit": "ae86e1ae9fc4f4d550e3ee9357d3ec9d34554270",
           "url": "https://github.com/spotify/heroic-grafana-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2620,6 +2620,11 @@
           "version": "2.4.3",
           "commit": "97716133091c386f70b3e2c2cfcf14bbc61cfbce",
           "url": "https://github.com/instana/instana-grafana-datasource"
+        },
+        {
+          "version": "2.4.4",
+          "commit": "cdbcd6c72d56498535af9bccac6ce4af19bab497",
+          "url": "https://github.com/instana/instana-grafana-datasource"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -848,6 +848,18 @@
       ]
     },
     {
+      "id": "heroic-grafana-datasource",
+      "type": "datasource",
+      "url": "https://github.com/spotify/heroic-grafana-datasource",
+      "versions": [
+        {
+          "version": "0.0.1",
+          "commit": "62b7240c35f7d0a45cd036641ffb3c4bf854aa87",
+          "url": "https://github.com/spotify/heroic-grafana-datasource"
+        }
+      ]
+    },
+    {
       "id": "udoprog-heroic-datasource",
       "type": "datasource",
       "url": "https://github.com/udoprog/udoprog-heroic-datasource",

--- a/repo.json
+++ b/repo.json
@@ -3223,6 +3223,11 @@
           "version": "0.5.0",
           "commit": "7f066caeef71a1401522793045fc56f041bafd01",
           "url": "https://github.com/algenty/grafana-flowcharting"
+        },
+        {
+          "version": "0.6.0",
+          "commit": "47a9f077cf5d269c53ba81bbe9458cc599233db5",
+          "url": "https://github.com/algenty/grafana-flowcharting"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -685,6 +685,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "4.0.2",
+          "commit": "11369b625c7e6e0eaf715119d0e8c11ade58ef3b",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "4.0.1",
           "commit": "affef3c282132895de9f721f1908c95e25dd300f",
           "url": "https://github.com/OpenNMS/opennms-helm"

--- a/repo.json
+++ b/repo.json
@@ -836,13 +836,13 @@
       ]
     },
     {
-      "id": "heroic-grafana-datasource",
+      "id": "spotify-heroic-datasource",
       "type": "datasource",
       "url": "https://github.com/spotify/heroic-grafana-datasource",
       "versions": [
         {
           "version": "0.0.1",
-          "commit": "afb9853e41e81a906b543680603aaabe11a0e557",
+          "commit": "fb557abb3b8c411000400c5aff9ec0d7423fdd32",
           "url": "https://github.com/spotify/heroic-grafana-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3090,6 +3090,11 @@
           "version": "1.0.1",
           "commit": "ac51829a66327992b53b3737afae74b65759f8bc",
           "url": "https://github.com/farski/blendstat-grafana"
+        },
+        {
+          "version": "1.0.2",
+          "commit": "d53bf7cb069793d6a051897efd83ae84e3b01d2b",
+          "url": "https://github.com/farski/blendstat-grafana"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -685,6 +685,16 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "4.0.1",
+          "commit": "affef3c282132895de9f721f1908c95e25dd300f",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
+          "version": "4.0.0",
+          "commit": "12cc57953ac69232d992d4476856ef28f9266bc9",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "3.0.1",
           "commit": "94fc9a3de676b4d993114cff119dec425fa502af",
           "url": "https://github.com/OpenNMS/opennms-helm"

--- a/repo.json
+++ b/repo.json
@@ -3452,8 +3452,8 @@
       "url": "https://github.com/alexandrainst/alexandra-trackmap-panel",
       "versions": [
         {
-          "version": "1.2.0",
-          "commit": "b383485053bcedcf18ab75be1b04a995e7b9c464",
+          "version": "1.2.3",
+          "commit": "d192a2b2a2f230e7bf8afa3248c3e86ca9a8388c",
           "url": "https://github.com/alexandrainst/alexandra-trackmap-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2459,6 +2459,11 @@
           "version": "1.0.4",
           "commit": "5b46bfb30c3de7c14b72d8f5fb0b50f6790a78e0",
           "url": "https://github.com/CorpGlory/grafana-progress-list"
+        },
+        {
+          "version": "1.0.5",
+          "commit": "79290de8335ded71245daa52aa2b345dbaaf687a",
+          "url": "https://github.com/CorpGlory/grafana-progress-list"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2796,6 +2796,11 @@
           "version": "1.3.9",
           "commit": "dd2f43e0eb54bb86110243691d87eb0e0c3e7e3b",
           "url": "https://github.com/akumuli/akumuli-datasource"
+        },
+        {
+          "version": "1.3.10",
+          "commit": "c346302575d2a41b5c408f4c91747b08e4f0d7c9",
+          "url": "https://github.com/akumuli/akumuli-datasource"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3153,6 +3153,11 @@
           "version": "0.4.0",
           "commit": "564b3e44362452582df764c6de5fceb4730fd741",
           "url": "https://github.com/algenty/grafana-flowcharting"
+        },
+        {
+          "version": "0.5.0",
+          "commit": "7f066caeef71a1401522793045fc56f041bafd01",
+          "url": "https://github.com/algenty/grafana-flowcharting"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -842,7 +842,7 @@
       "versions": [
         {
           "version": "0.0.1",
-          "commit": "ae86e1ae9fc4f4d550e3ee9357d3ec9d34554270",
+          "commit": "afb9853e41e81a906b543680603aaabe11a0e557",
           "url": "https://github.com/spotify/heroic-grafana-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2951,18 +2951,13 @@
       "url": "https://github.com/flant/grafana-statusmap",
       "versions": [
         {
-          "version": "0.0.4",
-          "commit": "e1abad408e71cef5b92ef9ab5fbc0bd0503cd22e",
-          "url": "https://github.com/flant/grafana-statusmap"
-        },
-        {
-          "version": "0.1.0",
-          "commit": "624be3450dc3025929a1bf0d2f745bbbb393b6b1",
-          "url": "https://github.com/flant/grafana-statusmap"
-        },
-        {
           "version": "0.1.1",
           "commit": "742e80d7135271fd01419c96137c1dfd0754d144",
+          "url": "https://github.com/flant/grafana-statusmap"
+        },
+        {
+          "version": "0.2.0",
+          "commit": "1e7ef33b67eafedd24bbc42b9bb5a2c18338f16e",
           "url": "https://github.com/flant/grafana-statusmap"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3500,6 +3500,18 @@
       ]
     },
     {
+      "id": "macropower-analytics-panel",
+      "type": "panel",
+      "url": "https://github.com/MacroPower/macropower-analytics-panel",
+      "versions": [
+        {
+          "version": "0.0.1",
+          "commit": "cf24374926a0ec2cbd63d87898a17532639185d0",
+          "url": "https://github.com/MacroPower/macropower-analytics-panel"
+        }
+      ]
+    },
+    {
       "id": "jeanbaptistewatenberg-percent-panel",
       "type": "panel",
       "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus",

--- a/repo.json
+++ b/repo.json
@@ -3039,6 +3039,11 @@
           "version": "1.2.4",
           "commit": "314dea6894a3d3565e71fc06453811525b2258a6",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.5",
+          "commit": "168e6456f3372ba17c46d12d5e531f27f2c3a96b",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3487,6 +3487,11 @@
           "version": "1.1.1",
           "commit": "4106da4f02e73a5a7fb62d1fd5177c37cbb46f81",
           "url": "https://github.com/devopsprodigy/kubegraf"
+        },
+        {
+          "version": "1.2.0",
+          "commit": "a860c9b2a6a2780fadbb43ee837f5f94bead0283",
+          "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2171,6 +2171,11 @@
       "url": "https://github.com/netxms/grafana",
       "versions": [
         {
+          "version": "1.2.1",
+          "commit": "50e006c1ec8959bb0a3822bf10a42554a6a0e2ee",
+          "url": "https://github.com/netxms/grafana"
+        },
+        {
           "version": "1.1.0",
           "commit": "e28ec9a0764bd0df45d81305443ce541ae177957",
           "url": "https://github.com/netxms/grafana"

--- a/scripts/lintPlugin.js
+++ b/scripts/lintPlugin.js
@@ -3,7 +3,7 @@ const semver = require('semver');
 const { fetchPluginJson } = require('./github/github');
 
 const PLUGIN_TYPES = ['datasource', 'panel', 'app', 'renderer'];
-const PLUGIN_ID_PATTERN = new RegExp(`^[a-z0-9]+(-[a-z0-9]+)*-(${PLUGIN_TYPES.join('|')})$`);
+const PLUGIN_ID_PATTERN = new RegExp(`^[A-Za-z0-9]+(-[A-Za-z0-9]+)*-(${PLUGIN_TYPES.join('|')})$`);
 
 async function lintPlugin(url, commit, version, pluginId) {
   const postData = {

--- a/scripts/lintPlugin.js
+++ b/scripts/lintPlugin.js
@@ -3,7 +3,7 @@ const semver = require('semver');
 const { fetchPluginJson } = require('./github/github');
 
 const PLUGIN_TYPES = ['datasource', 'panel', 'app', 'renderer'];
-const PLUGIN_ID_PATTERN = new RegExp(`^[A-Za-z0-9]+(-[A-Za-z0-9]+)*-(${PLUGIN_TYPES.join('|')})$`);
+const PLUGIN_ID_PATTERN = new RegExp(`^[A-Za-z0-9]+(-[a-z0-9]+)*-(${PLUGIN_TYPES.join('|')})$`);
 
 async function lintPlugin(url, commit, version, pluginId) {
   const postData = {
@@ -142,7 +142,7 @@ async function getOrg(orgSlug) {
 }
 
 function getOrgSlug(pluginId) {
-  const result = /^([a-z0-9]+)(-[a-z0-9]+)*-(datasource|app|panel)$/.exec(pluginId);
+  const result = /^([A-Za-z0-9]+)(-[a-z0-9]+)*-(datasource|app|panel)$/.exec(pluginId);
   if (result && result.length > 1) {
     return result[1];
   }

--- a/scripts/lintPlugin.js
+++ b/scripts/lintPlugin.js
@@ -3,7 +3,7 @@ const semver = require('semver');
 const { fetchPluginJson } = require('./github/github');
 
 const PLUGIN_TYPES = ['datasource', 'panel', 'app', 'renderer'];
-const PLUGIN_ID_PATTERN = new RegExp(`^[A-Za-z0-9]+(-[a-z0-9]+)*-(${PLUGIN_TYPES.join('|')})$`);
+const PLUGIN_ID_PATTERN = new RegExp(`^[a-z0-9]+(-[a-z0-9]+)*-(${PLUGIN_TYPES.join('|')})$`);
 
 async function lintPlugin(url, commit, version, pluginId) {
   const postData = {
@@ -142,7 +142,7 @@ async function getOrg(orgSlug) {
 }
 
 function getOrgSlug(pluginId) {
-  const result = /^([A-Za-z0-9]+)(-[a-z0-9]+)*-(datasource|app|panel)$/.exec(pluginId);
+  const result = /^([a-z0-9]+)(-[a-z0-9]+)*-(datasource|app|panel)$/.exec(pluginId);
   if (result && result.length > 1) {
     return result[1];
   }


### PR DESCRIPTION
First publication of the Official, Spotify created Heroic (https://spotify.github.io/heroic/) datasource. This deprecates the udoprog-heroic-datasource  (https://github.com/udoprog/udoprog-heroic-datasource) which should be unpublished in-favor of this, supported/updated plugin. 


