### PR TITLE
Add percent plus panel plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3437,8 +3437,8 @@
       "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus",
       "versions": [
         {
-          "version": "1.0.2",
-          "commit": "a62a09de938f971a3595cab50e8ca3ad7e0ad416",
+          "version": "1.0.5",
+          "commit": "2f0e7f6938ff07cc6f34b7f80669e95b60ac2182",
           "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -53,9 +53,7 @@
       ]
     },
     {
-      "id": "btplc-status-dot-
-      
-      ",
+      "id": "btplc-status-dot-panel",
       "type": "panel",
       "url": "https://github.com/BT-OpenSource/bt-grafana-status-dot",
       "versions": [

--- a/repo.json
+++ b/repo.json
@@ -3433,7 +3433,7 @@
     },
     {
       "id": "JeanBaptisteWATENBERG-percent-panel",
-      "type": "panel",
+      "type": "panel"
       "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus",
       "versions": [
         {

--- a/repo.json
+++ b/repo.json
@@ -3434,13 +3434,13 @@
       ]
     },
     {
-      "id": "jean-baptiste-watenberg-percent-panel",
+      "id": "JeanBaptisteWATENBERG-percent-panel",
       "type": "panel",
       "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus",
       "versions": [
         {
-          "version": "1.0.1",
-          "commit": "75779d0e5a4ffbe1aa331c551e450ef1f0f6b663",
+          "version": "1.0.2",
+          "commit": "a62a09de938f971a3595cab50e8ca3ad7e0ad416",
           "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3432,13 +3432,13 @@
       ]
     },
     {
-      "id": "JeanBaptisteWATENBERG-percent-panel",
+      "id": "jeanbaptistewatenberg-percent-panel",
       "type": "panel",
       "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus",
       "versions": [
         {
-          "version": "1.0.5",
-          "commit": "2f0e7f6938ff07cc6f34b7f80669e95b60ac2182",
+          "version": "1.0.6",
+          "commit": "9e2785ea49c3f28092853a095d21400b50bd8280",
           "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3433,7 +3433,7 @@
     },
     {
       "id": "JeanBaptisteWATENBERG-percent-panel",
-      "type": "panel"
+      "type": "panel",
       "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus",
       "versions": [
         {

--- a/repo.json
+++ b/repo.json
@@ -53,7 +53,9 @@
       ]
     },
     {
-      "id": "btplc-status-dot-panel",
+      "id": "btplc-status-dot-
+      
+      ",
       "type": "panel",
       "url": "https://github.com/BT-OpenSource/bt-grafana-status-dot",
       "versions": [
@@ -3428,6 +3430,18 @@
           "version": "1.0.4",
           "commit": "5756b415325ff2798b1ef6cd8b8bc3ec969bef70",
           "url": "https://github.com/rockset/rockset-grafana"
+        }
+      ]
+    },
+    {
+      "id": "jean-baptiste-watenberg-percent-panel",
+      "type": "panel",
+      "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus",
+      "versions": [
+        {
+          "version": "1.0.1",
+          "commit": "75779d0e5a4ffbe1aa331c551e450ef1f0f6b663",
+          "url": "https://github.com/JeanBaptisteWATENBERG/grafana-percent-plus"
         }
       ]
     }


### PR DESCRIPTION
This pull requests adds percent plus panel plugin. 
This plugin aims at computing a percent metric. It's designed with heartbeat in mind with the idea to display an availability metric panel. But it can be used for any other percent computation.

This is my first grafana plugin contribution feel free to give me any feedback regarding it's implementation and style.