### PR TITLE
Update DevOpsProdigy KubeGraf App version to v1.2.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "8c86000868b3c8aaeb3c7cf47b5528cf52f01e2e",
+          "commit": "0494a96800a6aeccf47d368b8ecb340ff59293ac",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "d941bd3361dd72ef1f363e5b7df6a5810b6f4d7c",
+          "commit": "8c86000868b3c8aaeb3c7cf47b5528cf52f01e2e",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "afd89c39ebca86bd77525c616c5c57e49cbd10fb",
+          "commit": "d26efe2b328052d077f6cbb237900b0ba0f3e6f7",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "fee4fb7493474f61a8ced1ba1f69c48a8d3778a7",
+          "commit": "a75a95398bc458ad8404916ca410181459d2911f",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "598d1660f90609558bca862b611797ca5476198a",
+          "commit": "e3911ea9a58e782f16b2588bdddd8379c58ebb79",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3404,6 +3404,11 @@
           "version": "1.1.1",
           "commit": "4106da4f02e73a5a7fb62d1fd5177c37cbb46f81",
           "url": "https://github.com/devopsprodigy/kubegraf"
+        },
+        {
+          "version": "1.2.0",
+          "commit": "d941bd3361dd72ef1f363e5b7df6a5810b6f4d7c",
+          "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "d26efe2b328052d077f6cbb237900b0ba0f3e6f7",
+          "commit": "b048877b00012b1ea99720aec599891982062269",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "e3911ea9a58e782f16b2588bdddd8379c58ebb79",
+          "commit": "2924f7d64d0fbe8e6c75acf8e5fa43c8470024ab",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "1f60e9416bf9eb7040c862c16a96d1e96a44f5a4",
+          "commit": "afd89c39ebca86bd77525c616c5c57e49cbd10fb",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "109ef4baf19003332407637e88a9d553998827a5",
+          "commit": "598d1660f90609558bca862b611797ca5476198a",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "b048877b00012b1ea99720aec599891982062269",
+          "commit": "a860c9b2a6a2780fadbb43ee837f5f94bead0283",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "a75a95398bc458ad8404916ca410181459d2911f",
+          "commit": "109ef4baf19003332407637e88a9d553998827a5",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "0494a96800a6aeccf47d368b8ecb340ff59293ac",
+          "commit": "fee4fb7493474f61a8ced1ba1f69c48a8d3778a7",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3407,7 +3407,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "2924f7d64d0fbe8e6c75acf8e5fa43c8470024ab",
+          "commit": "1f60e9416bf9eb7040c862c16a96d1e96a44f5a4",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]


### PR DESCRIPTION
### New features
* Navigation improvement: 
    * Hide all button (for nodes and namespaces)
    * Show one node or namespace (by click with ctrl)
* Summary-row in namespace section in nodes-overview page
* Add restarts to pod's resource dashboard
* Add resource graphs to deployment's, daemonset's & statefulset's dashboards
* Add sidecars' resources to pod's, deployment's, daemonset's & statefulset's dashboards

### Bug Fixes
* Plugin's config link
* Node's cpu usage correct value
* Node's memory usage correct value
* N/A labels in nodes-overview page