### PR TITLE
Add macropower-analytics-panel

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3430,6 +3430,18 @@
           "url": "https://github.com/rockset/rockset-grafana"
         }
       ]
+    },
+    {
+      "id": "macropower-analytics-panel",
+      "type": "panel",
+      "url": "https://github.com/MacroPower/macropower-analytics-panel",
+      "versions": [
+        {
+          "version": "0.0.1",
+          "commit": "cf24374926a0ec2cbd63d87898a17532639185d0",
+          "url": "https://github.com/MacroPower/macropower-analytics-panel"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
macropower-analytics-panel is very simple. Visually, it is identical to mxswat-separator-panel. However, it also sends data (when the component is mounted and unmounted) to a server that is specified in the panel settings. If you have a server configured to accept these post requests, you can log traffic to particular dashboards. This is very helpful in enterprise environments, when you want to know who is using what dashboards. I have a full description and instructions in the README, which can be found here:

https://github.com/MacroPower/macropower-analytics-panel/blob/master/README.md