### PR TITLE
Update flant-statusmap-panel version to 0.2.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2941,18 +2941,13 @@
       "url": "https://github.com/flant/grafana-statusmap",
       "versions": [
         {
-          "version": "0.0.4",
-          "commit": "e1abad408e71cef5b92ef9ab5fbc0bd0503cd22e",
-          "url": "https://github.com/flant/grafana-statusmap"
-        },
-        {
-          "version": "0.1.0",
-          "commit": "624be3450dc3025929a1bf0d2f745bbbb393b6b1",
-          "url": "https://github.com/flant/grafana-statusmap"
-        },
-        {
           "version": "0.1.1",
           "commit": "742e80d7135271fd01419c96137c1dfd0754d144",
+          "url": "https://github.com/flant/grafana-statusmap"
+        },
+        {
+          "version": "0.2.0",
+          "commit": "1e7ef33b67eafedd24bbc42b9bb5a2c18338f16e",
           "url": "https://github.com/flant/grafana-statusmap"
         }
       ]


### PR DESCRIPTION
- migrate to TypeScript
- fixes to work in Grafana 6.3.0+

