### PR TITLE
Update akumuli-datasource to 1.3.10

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2791,6 +2791,11 @@
           "version": "1.3.9",
           "commit": "dd2f43e0eb54bb86110243691d87eb0e0c3e7e3b",
           "url": "https://github.com/akumuli/akumuli-datasource"
+        },
+        {
+          "version": "1.3.10",
+          "commit": "c346302575d2a41b5c408f4c91747b08e4f0d7c9",
+          "url": "https://github.com/akumuli/akumuli-datasource"
         }
       ]
     },


### PR DESCRIPTION
This version adds ability to set time shift per series (grafana can only set time shift for the entire panel, but setting it per series can be useful to compare different time intervals, e.g. this month with the previous one).

Simple test:
- set up datasource using url: http://206.189.27.155:8181
- create panel with one query: parameters are `Metric` set to 'http.total', `Tags` set to 'endpoint=Gap.com'
- duplicate the query and edit it by setting `Time Shift` to '10m', you should see that the second graph is shifted back in time.