### PR TITLE
Update akumuli-datasource to 1.3.11

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2836,7 +2836,7 @@
         },
         {
           "version": "1.3.11",
-          "commit": "d8512a1b862b9c9a58051f56e0c98ff9473039dd",
+          "commit": "98ecc90c2810dd5cf919c057408c00304ab2ba11",
           "url": "https://github.com/akumuli/akumuli-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2836,7 +2836,7 @@
         },
         {
           "version": "1.3.11",
-          "commit": "5e063f15b669819a46baa4c069b617de941115fb",
+          "commit": "d8512a1b862b9c9a58051f56e0c98ff9473039dd",
           "url": "https://github.com/akumuli/akumuli-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2833,6 +2833,11 @@
           "version": "1.3.10",
           "commit": "c346302575d2a41b5c408f4c91747b08e4f0d7c9",
           "url": "https://github.com/akumuli/akumuli-datasource"
+        },
+        {
+          "version": "1.3.11",
+          "commit": "5e063f15b669819a46baa4c069b617de941115fb",
+          "url": "https://github.com/akumuli/akumuli-datasource"
         }
       ]
     },


### PR DESCRIPTION
Add Group-by/Pivot-by query support.

How to test:

- set up datasource using url: http://206.189.27.155:8181
- create panel with one query: parameters are Metric set to 'http.total', Tags set to 'endpoint=Gap.com'
  (at this point you should be able to see series name `http.total:mean collector=probe endpoint=Gap.com interval=60 monitor_type=http orgid=44 unit=state` on the plot)
- Click `+` on the 'Group By Tag' control, enter name 'collector' (you should see the auto-complete suggestions) and click `add tag`. The series name should change to `http.total endpoint=Gap.com interval=60 monitor_type=http orgid=44 unit=state` (note that 'collector' tag is gone).
- Remove tag by clicking the `x` mark. The series name should change to original value.
- Click `+` on the 'Pivot By Tag' control, enter name 'endpoint' and click `add tag`. The series name should turn into `http.total endpoint=Gap.com`.