### PR TITLE
add tdengine datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3598,6 +3598,18 @@
           "url": "https://github.com/grafana/strava-datasource"
         }
       ]
+    },
+    {
+      "id": "taosdata-tdengine-datasource",
+      "type": "datasource",
+      "url": "https://github.com/taosdata/TDengine/tree/develop/src/connector/grafana/tdengine",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "1c943a71fda7ed39abeefa82f78a8cedf827e297",
+          "url": "https://github.com/taosdata/TDengine/tree/develop/src/connector/grafana/tdengine"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
TDengine is an open-sourced  timeseries database for IOT .

this is a datasource plugin  for grafana user to query data from TDengine.

1. set up tdengine 
    * build from source could refer https://github.com/taosdata/TDengine
    * or you could download the newest packages from https://www.taosdata.com/en/getting-started/
    * or use docker pull tdengine/tdengine:latest
2. after setup 
     you could import the sample dashboard to test.
https://github.com/taosdata/TDengine/blob/develop/src/connector/grafana/tdengine/dashboard/tdengine-grafana.json
