### PR TITLE
Clickhouse Datasource plugin version update to 1.9.5

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2062,8 +2062,8 @@
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
         },
         {
-          "version": "1.9.4",
-          "commit": "08c152e7eb95dde2f178184a6a6447918b4b847f",
+          "version": "1.9.5",
+          "commit": "50d46ef5138f5b5d8098c1cbacc7f0d3f56e16a9",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2038,6 +2038,11 @@
           "version": "1.9.3",
           "commit": "995b21bea651d2afbe8eea33b38dbe457349931d",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "1.9.4",
+          "commit": "08c152e7eb95dde2f178184a6a6447918b4b847f",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },


### PR DESCRIPTION
See release notes here: https://github.com/Vertamedia/clickhouse-grafana/releases/tag/1.9.5

## Fixes 
* Comments not supported by sql language parser #95 
* Ad Hoc Filters small adjustments for numeric values
* UI optimizations within Metric builder