### PR TITLE
OpenNMS Helm 5.0.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -690,6 +690,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "5.0.1",
+          "commit": "b1c7e0e78901ce46a32c8f5f4c28b36d8106e30d",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "5.0.0",
           "commit": "8df81a05cbc5df0bcb77d77e35ed305b3be702b9",
           "url": "https://github.com/OpenNMS/opennms-helm"

--- a/repo.json
+++ b/repo.json
@@ -690,6 +690,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "5.0.0",
+          "commit": "8df81a05cbc5df0bcb77d77e35ed305b3be702b9",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "4.0.2",
           "commit": "11369b625c7e6e0eaf715119d0e8c11ade58ef3b",
           "url": "https://github.com/OpenNMS/opennms-helm"


### PR DESCRIPTION
This PR bumps to the latest OpenNMS Helm plugin release.

### Release Notes

This release fixes a number of issues, most notably compatibility with newer Grafana releases.
These fixes necessitated dropping compatibility with Grafana versions older than 6.3, so we have bumped the major version of Helm to 5.

Additionally, documentation has been improved and a number of behind-the-scenes changes have been made related to continuous integration and build system.

* [HELM-64: Node search allows only to select the first 25 nodes](https://issues.opennms.org/browse/HELM-64)
* [HELM-196: Alarm table rendering failures with Grafana 6.5.2](https://issues.opennms.org/browse/HELM-196)
* [HELM-201: Panel Refreshes After Each Request When Clearing Multiple Alarms](https://issues.opennms.org/browse/HELM-201)
* [HELM-202: Alarms details modal shows wrong alarm when table is sorted](https://issues.opennms.org/browse/HELM-202)
* [HELM-208: Error appears when selecting filter type](https://issues.opennms.org/browse/HELM-208)
* [HELM-212: number (count) columns render wrong in Grafana 6.5 and 6.6](https://issues.opennms.org/browse/HELM-212)