### PR TITLE
Server-Eye DataSource v0.0.4

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3688,8 +3688,8 @@
       "url": "https://github.com/Server-Eye/grafana-plugin",
       "versions": [
         {
-          "version": "0.0.2",
-          "commit": "0bb854ee48a224c4146e1a8afdf5dbd783078f80",
+          "version": "0.0.3",
+          "commit": "01cbf7fe762d82e3994577f9d663ebf0e8c466ec",
           "url": "https://github.com/Server-Eye/grafana-plugin"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2688,7 +2688,6 @@
           "commit": "112018a436fd5330df448e3372702265d103f9a5",
           "url": "https://github.com/instana/instana-grafana-datasource"
         }
-
       ]
     },
     {
@@ -3680,6 +3679,18 @@
           "version": "1.0.1",
           "commit": "9356b5b3876ebf148299415c90aa337f1a9e9638",
           "url": "https://github.com/grafana/strava-datasource"
+        }
+      ]
+    },
+    {
+      "id": "server-eye-data-source",
+      "type": "datasource",
+      "url": "https://github.com/Server-Eye/grafana-plugin",
+      "versions": [
+        {
+          "version": "0.0.2",
+          "commit": "0bb854ee48a224c4146e1a8afdf5dbd783078f80",
+          "url": "https://github.com/Server-Eye/grafana-plugin"
         }
       ]
     }

--- a/repo.json
+++ b/repo.json
@@ -3683,13 +3683,13 @@
       ]
     },
     {
-      "id": "server-eye-data-source",
+      "id": "servereye-datasource",
       "type": "datasource",
       "url": "https://github.com/Server-Eye/grafana-plugin",
       "versions": [
         {
-          "version": "0.0.3",
-          "commit": "01cbf7fe762d82e3994577f9d663ebf0e8c466ec",
+          "version": "0.0.4",
+          "commit": "1a8a45bb18c4f761c2602744a06229450e3cb99d",
           "url": "https://github.com/Server-Eye/grafana-plugin"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3689,7 +3689,7 @@
       "versions": [
         {
           "version": "0.0.4",
-          "commit": "1a8a45bb18c4f761c2602744a06229450e3cb99d",
+          "commit": "e795acbdc47ceb3180923eafcda1e73962280448",
           "url": "https://github.com/Server-Eye/grafana-plugin"
         }
       ]


### PR DESCRIPTION
Hi, 

trying to get this into the grafana store for our customers.

It might fall under the rule for commercial plugins as far as I understand it.

For testing you will require a valid API key aswell as valid agentIds, which I can share upon a short, formless request to [jan.aumann@server-eye.de](mailto:jan.aumann@server-eye.de).

Thanks in advance!