### PR TITLE
Release grafana-image-renderer v1.0.10

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3559,6 +3559,25 @@
               "md5": "659b18917e363d983e6da2fc067e867c"
             }
           }
+        },
+        {
+          "version": "1.0.10",
+          "commit": "cfb823dc0ee9ba0b93f862ee53eb9427b5242fc0",
+          "url": "https://github.com/grafana/grafana-image-renderer",
+          "download": {
+            "darwin-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.10/plugin-darwin-x64-unknown.zip",
+              "md5": "79810bb881fc146c51d1645766bc742f"
+            },
+            "linux-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.10/plugin-linux-x64-glibc.zip",
+              "md5": "f04c7c9f33175e0570251d7788f1f937"
+            },
+            "windows-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.10/plugin-win32-x64-unknown.zip",
+              "md5": "3ee7bbc15db33416d938ff8307d8649c"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
https://github.com/grafana/grafana-image-renderer/releases/tag/v1.0.10