### PR TITLE
HDS Datasource plugin v1.0.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2963,8 +2963,8 @@
       "url": "https://github.com/linksmart/grafana-hds-datasource",
       "versions": [
         {
-          "version": "1.0.0",
-          "commit": "9cb2c740e78d1b09b7e920271689281fd52916f7",
+          "version": "1.0.1",
+          "commit": "36388a6bc4a94d197bf90513248e9df564323a7f",
           "url": "https://github.com/linksmart/grafana-hds-datasource"
         }
       ]


### PR DESCRIPTION
Hi, 
This is update to the existing open source [HDS datasource plugin](https://github.com/linksmart/grafana-hds-datasource)  with following minor changes

- Support latest version of [HDS](https://github.com/linksmart/historical-datastore)
- Link compatibility matrix
- Bug fixes

This plugin can be tested with a fake HDS server (with continuously growing dummy senML data) by running following command:
```
docker run -p 8085:8085  linksmart/hds -demo -conf /conf/docker.json
```

Thank you.