### PR TITLE
Add TDengine Plugin in the repo.json

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3726,6 +3726,18 @@
           "url": "https://github.com/grafana/strava-datasource"
         }
       ]
+    },
+    {
+      "id": "taosdata-tdengine-datasource",
+      "type": "datasource",
+      "url": "https://github.com/taosdata/grafanaplugin",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "525c2492a7a985ba3c1a0880aad026e6553e94dc",
+          "url": "https://github.com/taosdata/grafanaplugin"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This is a new pull request to replace the old one submitted by my colleague, #547

TDengine is an open-sourced timeseries database for IOT .

this is a datasource plugin for grafana user to query data from TDengine.

set up tdengine
build from source could refer https://github.com/taosdata/TDengine
or you could download the newest packages from https://www.taosdata.com/en/getting-started/
or use docker pull tdengine/tdengine:latest
after setup
you could import the sample dashboard to test.
https://github.com/taosdata/grafanaplugin/dashboard/tdengine-grafana.json