### PR TITLE
MQTT panel plugin v0.3.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3960,12 +3960,12 @@
     {
       "id": "gapit-mqtt-panel",
       "type": "panel",
-      "url": "https://github.com/gapitio/grafana-plugin-repository",
+      "url": "https://github.com/gapitio/grafana-mqtt-panel",
       "versions": [
         {
           "version": "0.3.0",
           "commit": "a6511056449abd2e6b1fdbd37d9d312c74a36346",
-          "url": "https://github.com/gapitio/grafana-plugin-repository"
+          "url": "https://github.com/gapitio/grafana-mqtt-panel"
         }
       ]
     }

--- a/repo.json
+++ b/repo.json
@@ -3964,7 +3964,7 @@
       "versions": [
         {
           "version": "0.3.0",
-          "commit": "1d528adb20b8cc0d66b61c923424ddc9b2777a41",
+          "commit": "a6511056449abd2e6b1fdbd37d9d312c74a36346",
           "url": "https://github.com/gapitio/grafana-plugin-repository"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3964,7 +3964,7 @@
       "versions": [
         {
           "version": "0.3.0",
-          "commit": "f192531ba6b1ffa92e96eb1258a4039c979dc18d",
+          "commit": "6d121baadca1d02a12057e948826a98da778240b",
           "url": "https://github.com/gapitio/grafana-mqtt-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3956,6 +3956,18 @@
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]
+    },
+    {
+      "id": "gapit-mqtt-panel",
+      "type": "datasource",
+      "url": "https://github.com/gapitio/grafana-plugin-repository",
+      "versions": [
+        {
+          "version": "0.3.0",
+          "commit": "a6511056449abd2e6b1fdbd37d9d312c74a36346",
+          "url": "https://github.com/gapitio/grafana-plugin-repository"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -3963,8 +3963,8 @@
       "url": "https://github.com/gapitio/grafana-mqtt-panel",
       "versions": [
         {
-          "version": "0.3.0",
-          "commit": "6d121baadca1d02a12057e948826a98da778240b",
+          "version": "0.3.1",
+          "commit": "97b53758052c477a5793129fd04bceb9dda8ad91",
           "url": "https://github.com/gapitio/grafana-mqtt-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3964,7 +3964,7 @@
       "versions": [
         {
           "version": "0.3.0",
-          "commit": "a6511056449abd2e6b1fdbd37d9d312c74a36346",
+          "commit": "1d528adb20b8cc0d66b61c923424ddc9b2777a41",
           "url": "https://github.com/gapitio/grafana-plugin-repository"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3744,7 +3744,7 @@
       "versions": [
         {
           "version": "0.2.0",
-          "commit": "03b2073ce43eb20c878ee22ebf8084450e081722",
+          "commit": "b30cd2553ef9abd610cb04960ed1deb051f455ba",
           "url": "https://github.com/gapitio/grafana-mqtt-panel.git"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3964,7 +3964,7 @@
       "versions": [
         {
           "version": "0.3.0",
-          "commit": "a6511056449abd2e6b1fdbd37d9d312c74a36346",
+          "commit": "cfaea2c720290efa262db56b9961a067975ad841",
           "url": "https://github.com/gapitio/grafana-mqtt-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3964,7 +3964,7 @@
       "versions": [
         {
           "version": "0.3.0",
-          "commit": "cfaea2c720290efa262db56b9961a067975ad841",
+          "commit": "f192531ba6b1ffa92e96eb1258a4039c979dc18d",
           "url": "https://github.com/gapitio/grafana-mqtt-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3963,8 +3963,8 @@
       "url": "https://github.com/gapitio/grafana-mqtt-panel",
       "versions": [
         {
-          "version": "0.3.1",
-          "commit": "97b53758052c477a5793129fd04bceb9dda8ad91",
+          "version": "0.3.4",
+          "commit": "ad37e9e1aa8b00c92eb1757a445089766f4a1789",
           "url": "https://github.com/gapitio/grafana-mqtt-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3959,7 +3959,7 @@
     },
     {
       "id": "gapit-mqtt-panel",
-      "type": "datasource",
+      "type": "panel",
       "url": "https://github.com/gapitio/grafana-plugin-repository",
       "versions": [
         {

--- a/repo.json
+++ b/repo.json
@@ -3736,6 +3736,18 @@
           "url": "https://github.com/grafana/strava-datasource"
         }
       ]
+    },
+    {
+      "id": "grafana-mqtt-panel",
+      "type": "panel",
+      "url": "https://github.com/gapitio/grafana-mqtt-panel.git",
+      "versions": [
+        {
+          "version": "0.2.0",
+          "commit": "03b2073ce43eb20c878ee22ebf8084450e081722",
+          "url": "https://github.com/gapitio/grafana-mqtt-panel.git"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This plugin communicates with a MQTT broker through websocket to transmit and receive data.

It's used to get real time data from equipment, but can be used with anything that can send data to an MQTT broker.