### PR TITLE
Update Multistat version to 1.2.6

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3161,6 +3161,11 @@
           "version": "1.2.5",
           "commit": "168e6456f3372ba17c46d12d5e531f27f2c3a96b",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.6",
+          "commit": "76875fd0c5f19ed93f309f86fcf012692fc7bfa5",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3164,7 +3164,7 @@
         },
         {
           "version": "1.2.6",
-          "commit": "76875fd0c5f19ed93f309f86fcf012692fc7bfa5",
+          "commit": "3b6426b88332d831cda722237abd7e60436d537b",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3164,7 +3164,7 @@
         },
         {
           "version": "1.2.6",
-          "commit": "3b6426b88332d831cda722237abd7e60436d537b",
+          "commit": "032789dd8ffc877ec88b7dbbdcc8f9cb45569dbe",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]


### PR DESCRIPTION
Provides backwards-compatible fix to the panel-content class needed for grafana 6.6.7-beta
Plus small cosmetic calculation fixes to showLines and showDots positions

Also adds support for snapshots