### PR TITLE
Add kdb+ datasource v1.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3766,13 +3766,13 @@
       ]
     },
     {
-      "id": "aquaq-kdb-websocket-adaptor",
+      "id": "aquaqanalytics-kdbadaptor-datasource",
       "type": "datasource",
       "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws",
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "e5cb3dbaf922a0e2f5832f4310a66c9e30eeb24c",
+          "commit": "f1c15ddc0eb9761f622cf00ccfc6dd478bf5561c",
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3771,8 +3771,8 @@
       "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws",
       "versions": [
         {
-          "version": "1.0.0",
-          "commit": "f1c15ddc0eb9761f622cf00ccfc6dd478bf5561c",
+          "version": "1.0.1",
+          "commit": "9b39310d7254d5bb4f2d28f9ca48320ac5df1140",
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3772,7 +3772,7 @@
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "f1495b10ecc73e0f5a99707b18ac13f1167824f5",
+          "commit": "e5cb3dbaf922a0e2f5832f4310a66c9e30eeb24c",
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3772,7 +3772,7 @@
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "52fa4efbce51afca9e71816d7b564aed651e3b3e",
+          "commit": "f1495b10ecc73e0f5a99707b18ac13f1167824f5",
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3764,6 +3764,18 @@
           "url": "https://github.com/grafana/strava-datasource"
         }
       ]
+    },
+    {
+      "id": "aquaq-kdb-websocket-adaptor",
+      "type": "datasource",
+      "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "52fa4efbce51afca9e71816d7b564aed651e3b3e",
+          "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This is a new data-source plugin to enable connection to kdb+ historic and real-time databases over WebSockets. It has the ability to build custom queries over the 'Built Query' panel, or run free-form queries/functions, both supporting conflation and grouping. Tabular visualisations are also supported in both panel types.

Test:
 - Download [latest version of kdb+](https://kx.com/connect-with-us/download/) and setup as [described by kx](https://code.kx.com/v2/learn/install/).
 - Open a listening port and set WebSocket message handler as shown in README.md:

```
\p 6990
.z.ws:{ds:-9!x;neg[.z.w] -8! `o`ID!(@[value;ds[`i];{`$"'",x}];ds[`ID])}
```

 - Connect grafana data-source as described in README.md (Host: `localhost:6990`).
 - Save & Test
 - Examples of test data sets are [available from the kx github](https://github.com/KxSystems/kdb)

```
/ 10000 sample market trades
q)nt:10000
q)t:`time xasc ([]sym:nt#`FDP;time:09:30t+nt?06:30t;price:100+(nt?100)%100;size:100*1+nt?10)
/ time is required in timestamp format
q)update time:.z.d+time from `t
/ in-memory table should have both grouped and sorted attributes
q)update `s#time,`g#sym from `t
```

 - Navigate to new Dashboard -> add Query
 - Under 'From' select 't'
 - Under 'Time Column' select 'time'
 - Under 'Select' select 'price'
 - Set the time-range in Grafana to last 24 hr
