### PR TITLE
Update Annunciator panel to v1.0.3 to fix Grafana 6.7.0+ DOM changes

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2383,7 +2383,7 @@
         },
         {
           "version": "1.0.3",
-          "commit": "9d20696108a4f300bd1db9f32b5d1020a00932da",
+          "commit": "cc8e7fdb9b1f058c560376abbfd4c4d4888b4695",
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2380,6 +2380,11 @@
           "version": "1.0.2",
           "commit": "dfc33b15a6f3663be7b840197b22b3c2865c9ae5",
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+        },
+        {
+          "version": "1.0.3",
+          "commit": "9d20696108a4f300bd1db9f32b5d1020a00932da",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
         }
       ]
     },


### PR DESCRIPTION
Tiny fix to accommodate the DOM structure changes in Grafana 6.7.0+
