### PR TITLE
Add Untimely panel plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4299,6 +4299,18 @@
           "url": "https://github.com/Clarity-89/grafana-finnhub"
         }
       ]
+    },
+    {
+      "id": "factrylabs-untimely-panel",
+      "type": "panel",
+      "url": "https://github.com/factrylabs/untimely-grafana-panel",
+      "versions": [
+        {
+          "version": "0.1.1",
+          "commit": "78fb7a9c1622a632721a14838dc5005f8aabcd90",
+          "url": "https://github.com/factrylabs/untimely-grafana-panel"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
The Untimely Grafana plugin is a panel that facilitates working with distances on the x-axis (or anything else that isn't time).

You add queries to your visualization, then select the query that represents the x-axis. The different series will then be interlinked based on their timestamps.