### PR TITLE
Add Plotly panel plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3880,7 +3880,7 @@
       "versions": [
         {
           "version": "0.2.1",
-          "commit": "95b0b28ae01baab35703fff8c59f41de309c22bb",
+          "commit": "c5576cc7559694d62a684ebd501bf7d91540c335",
           "url": "https://github.com/ae3e/ae3e-plotly-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3872,6 +3872,18 @@
           "url": "https://github.com/grafana/strava-datasource"
         }
       ]
-    }
+    },
+    {
+      "id": "ae3e-plotly-panel",
+      "type": "panel",
+      "url": "https://github.com/ae3e/ae3e-plotly-panel",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "commit": "7a483a844b859be9bd871b083ed59028be75d9dd",
+          "url": "https://github.com/ae3e/ae3e-plotly-panel"
+        }
+      ]
+    }	   
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -3884,6 +3884,23 @@
           "url": "https://github.com/ae3e/ae3e-plotly-panel"
         }
       ]
+    },
+    {
+      "id": "ae3e-plotly-panel",
+      "type": "panel",
+      "url": "https://github.com/ae3e/ae3e-plotly-panel",
+      "versions": [
+        {
+          "version": "0.2.1",
+          "commit": "869abea8b30cc0af7a54bba5db9f2bfa627771a6",
+          "url": "https://github.com/ae3e/ae3e-plotly-panel"
+        },
+        {
+          "version": "0.1.0",
+          "commit": "7a483a844b859be9bd871b083ed59028be75d9dd",
+          "url": "https://github.com/ae3e/ae3e-plotly-panel"
+        }
+      ]
     }	   
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -3879,25 +3879,8 @@
       "url": "https://github.com/ae3e/ae3e-plotly-panel",
       "versions": [
         {
-          "version": "0.1.0",
-          "commit": "e1685343df948b503b95c89ec67fd156eaeebdee",
-          "url": "https://github.com/ae3e/ae3e-plotly-panel"
-        }
-      ]
-    },
-    {
-      "id": "ae3e-plotly-panel",
-      "type": "panel",
-      "url": "https://github.com/ae3e/ae3e-plotly-panel",
-      "versions": [
-        {
           "version": "0.2.1",
-          "commit": "869abea8b30cc0af7a54bba5db9f2bfa627771a6",
-          "url": "https://github.com/ae3e/ae3e-plotly-panel"
-        },
-        {
-          "version": "0.1.0",
-          "commit": "7a483a844b859be9bd871b083ed59028be75d9dd",
+          "commit": "7ac1e0c551fd30d55d2fff376bc2f952f54af301",
           "url": "https://github.com/ae3e/ae3e-plotly-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3880,7 +3880,7 @@
       "versions": [
         {
           "version": "0.1.0",
-          "commit": "7a483a844b859be9bd871b083ed59028be75d9dd",
+          "commit": "e1685343df948b503b95c89ec67fd156eaeebdee",
           "url": "https://github.com/ae3e/ae3e-plotly-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -1,6 +1,30 @@
 {
   "plugins": [
     {
+      "id": "ae3e-plotly-panel",
+      "type": "panel",
+      "url": "https://github.com/ae3e/ae3e-plotly-panel",
+      "versions": [
+        {
+          "version": "0.2.1",
+          "commit": "c5576cc7559694d62a684ebd501bf7d91540c335",
+          "url": "https://github.com/ae3e/ae3e-plotly-panel"
+        }
+      ]
+    },
+    {
+      "id": "aceiot-svg-panel",
+      "type": "panel",
+      "url": "https://github.com/ACE-IoT-Solutions/ace-svg-react",
+      "versions": [
+        {
+          "version": "0.0.8",
+          "commit": "690d4ffe0753125b64e52a5f5a88f11bf37ca33f",
+          "url": "https://github.com/ACE-IoT-Solutions/ace-svg-react"
+        }
+      ]
+    },
+    {
       "id": "novatec-sdg-panel",
       "type": "panel",
       "url": "https://github.com/NovatecConsulting/novatec-service-dependency-graph-panel",
@@ -352,6 +376,17 @@
       "type": "app",
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
+        {
+          "version": "4.0.1",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix",
+          "commit": "95aee8f0488eb87b0c061f234f815e0e11f6f129",
+          "download": {
+            "any": {
+              "url": "https://github.com/alexanderzobnin/grafana-zabbix/releases/download/v4.0.1/alexanderzobnin-zabbix-app-4.0.1.zip",
+              "md5": "24f92c7c4ee898a0bdaedc9a17718e0a"
+            }
+          }
+        },
         {
           "version": "4.0.0",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix",
@@ -1926,6 +1961,11 @@
       "url": "https://github.com/Vonage/Grafana_Status_panel",
       "versions": [
         {
+          "version": "1.0.10",
+          "commit": "ca77e0dd94b27088f071f8d61a67fe0256faca2f",
+          "url": "https://github.com/Vonage/Grafana_Status_panel"
+        },
+        {
           "version": "1.0.9",
           "commit": "2a9b8e14e4622c611785117fbca3536c8f7f2ab2",
           "url": "https://github.com/Vonage/Grafana_Status_panel"
@@ -2240,6 +2280,11 @@
           "version": "1.0.5",
           "commit": "797eb0f59af942f50559d0d8098cb61b07fb4218",
           "url": "https://github.com/sni/grafana-pnp-datasource"
+        },
+        {
+          "version": "1.0.7",
+          "commit": "e6adb37b792e13c833f0cdd3fdb024587ce8c0c2",
+          "url": "https://github.com/sni/grafana-pnp-datasource"
         }
       ]
     },
@@ -2261,6 +2306,11 @@
         {
           "version": "1.0.3",
           "commit": "a3977184331020124b486309e320a08ab2a1f186",
+          "url": "https://github.com/sni/grafana-thruk-datasource"
+        },
+        {
+          "version": "1.0.5",
+          "commit": "cb19b67c688f063ad5982162c57158730175bb74",
           "url": "https://github.com/sni/grafana-thruk-datasource"
         }
       ]
@@ -2899,6 +2949,11 @@
         {
           "version": "3.0.0",
           "commit": "e01d51d5876037a10e57c7ceb60a14a868936975",
+          "url": "https://github.com/instana/instana-grafana-datasource"
+        },
+        {
+          "version": "3.0.1",
+          "commit": "b5c6a5140bf9d9e052f3b2bc9ba35e0cce047226",
           "url": "https://github.com/instana/instana-grafana-datasource"
         }
       ]
@@ -4277,6 +4332,11 @@
           "version": "0.5.0",
           "commit": "772a07bfec70308e171d6a742f9ef6e8fac48431",
           "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel"
+        },
+        {
+          "version": "0.6.0",
+          "commit": "3f27ca64de03c20e545fc6205fa3e6421b017c69",
+          "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel"
         }
       ]
     },
@@ -4294,6 +4354,11 @@
           "version": "0.2.0",
           "commit": "838257d2c353cb71f23c073af75ee3c62261fd96",
           "url": "https://github.com/marcusolsson/grafana-treemap-panel"
+        },
+        {
+          "version": "0.3.0",
+          "commit": "529907892b3012355367b5e2b30f75f73641526e",
+          "url": "https://github.com/marcusolsson/grafana-treemap-panel"
         }
       ]
     },
@@ -4305,6 +4370,31 @@
         {
           "version": "0.1.0",
           "commit": "3d4650d41a6de8ebd97a7e6ff124ace65b744503",
+          "url": "https://github.com/marcusolsson/grafana-static-datasource"
+        },
+        {
+          "version": "0.2.0",
+          "commit": "e8f0f8053a73e271a35e55c8f3461b335860f566",
+          "url": "https://github.com/marcusolsson/grafana-static-datasource"
+        },
+        {
+          "version": "0.3.0",
+          "commit": "4674ab1038b2f54b8bcb17f9c54f837664dae02d",
+          "url": "https://github.com/marcusolsson/grafana-static-datasource"
+        },
+        {
+          "version": "0.4.0",
+          "commit": "8217cb0291580d7f7d48e925269f47fc4a5a44e9",
+          "url": "https://github.com/marcusolsson/grafana-static-datasource"
+        },
+        {
+          "version": "1.0.0",
+          "commit": "d55ba22cacf8dc4f56426a3d14b4a7c219ef2ceb",
+          "url": "https://github.com/marcusolsson/grafana-static-datasource"
+        },
+        {
+          "version": "1.0.1",
+          "commit": "fdab57f9a7cc548713ff01e68114326163d484be",
           "url": "https://github.com/marcusolsson/grafana-static-datasource"
         }
       ]
@@ -4318,6 +4408,43 @@
           "version": "1.0.0",
           "commit": "bf3e8b02e700707be0aff16b0aa046a6c2c176c7",
           "url": "https://github.com/marcusolsson/grafana-dynamictext-panel"
+        },
+        {
+          "version": "1.0.1",
+          "commit": "83c5c1b05fc0c8a3096944d16039354f272daf34",
+          "url": "https://github.com/marcusolsson/grafana-dynamictext-panel"
+        }
+      ]
+    },
+    {
+      "id": "marcusolsson-json-datasource",
+      "type": "datasource",
+      "url": "https://github.com/marcusolsson/grafana-jsonapi-datasource",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "commit": "ebbc63060b78026a152e87fd1a10d5a6979a65e6",
+          "url": "https://github.com/marcusolsson/grafana-jsonapi-datasource"
+        },
+        {
+          "version": "0.2.0",
+          "commit": "118d1575ca2f4271433e62594a0ed4f543dba22a",
+          "url": "https://github.com/marcusolsson/grafana-jsonapi-datasource"
+        },
+        {
+          "version": "0.3.0",
+          "commit": "c539effee54e9a5551ea416faf271402f39503bc",
+          "url": "https://github.com/marcusolsson/grafana-jsonapi-datasource"
+        },
+        {
+          "version": "0.3.1",
+          "commit": "053d7457ab330f37581de5057334031026890c9a",
+          "url": "https://github.com/marcusolsson/grafana-jsonapi-datasource"
+        },
+        {
+          "version": "0.4.0",
+          "commit": "d03ecc56434ac86ba2032a5f311f17eb22141983",
+          "url": "https://github.com/marcusolsson/grafana-jsonapi-datasource"
         }
       ]
     },
@@ -4355,6 +4482,11 @@
         {
           "version": "2.1.1",
           "commit": "68e400abc134b1e724c055b56074d8b6a5ffd467",
+          "url": "https://github.com/Dalvany/dalvany-image-panel"
+        },
+        {
+          "version": "2.2.0",
+          "commit": "408f6a5ab93bebf41d42ccec3e83f68714d2986b",
           "url": "https://github.com/Dalvany/dalvany-image-panel"
         }
       ]
@@ -4435,16 +4567,16 @@
       ]
     },
     {
-      "id": "ae3e-plotly-panel",
+      "id": "dikshitashirodkar25-sunburst-panel",
       "type": "panel",
-      "url": "https://github.com/ae3e/ae3e-plotly-panel",
+      "url": "https://github.com/Dikshita25/sunburst-grafana-plugin",
       "versions": [
         {
-          "version": "0.2.1",
-          "commit": "c5576cc7559694d62a684ebd501bf7d91540c335",
-          "url": "https://github.com/ae3e/ae3e-plotly-panel"
+          "version": "1.0.1",
+          "commit": "6d372df203078cb36462af0309c3b92501aa3f23",
+          "url": "https://github.com/Dikshita25/sunburst-grafana-plugin"
         }
       ]
-    }	
+    }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -3880,7 +3880,7 @@
       "versions": [
         {
           "version": "0.2.1",
-          "commit": "7ac1e0c551fd30d55d2fff376bc2f952f54af301",
+          "commit": "95b0b28ae01baab35703fff8c59f41de309c22bb",
           "url": "https://github.com/ae3e/ae3e-plotly-panel"
         }
       ]


### PR DESCRIPTION
Unlike the [natel-plotly-panel](https://github.com/NatelEnergy/grafana-plotly-panel), this plugin is not limited to specific types of charts. But, on the other hand, the user interface is really rough in order to let users to set all options available in Plotly.