### PR TITLE
Update Annunciator to v1.0.5, adding new 'Shock & Awe' alarm indicator

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2393,7 +2393,7 @@
         },
         {
           "version": "1.0.5",
-          "commit": "3706498e0eabaf46b4e501eade3b445c0ef24a95",
+          "commit": "3796550c2d733b777f85f1536b086b1ade33b75b",
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2390,6 +2390,11 @@
           "version": "1.0.4",
           "commit": "b17afff7b7ac1e923b71485e004fe376558ff21f",
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+        },
+        {
+          "version": "1.0.5",
+          "commit": "3706498e0eabaf46b4e501eade3b445c0ef24a95",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
         }
       ]
     },


### PR DESCRIPTION
Added option to display unmistakable 'Shock and Awe' display using CSS animation to display threshold violations

