### PR TITLE
Add GraphQL datasource 

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4326,6 +4326,18 @@
           "url": "https://github.com/factrylabs/untimely-grafana-panel"
         }
       ]
+    },
+    {
+      "id": "fifemon-graphql-datasource",
+      "type": "datasource",
+      "url": "https://github.com/fifemon/graphql-datasource",
+      "versions": [
+        {
+          "version": "1.1.3",
+          "commit": "d0c0fbd29b75caa761ce0b55032e4196e55532c1",
+          "url": "https://github.com/fifemon/graphql-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Datasource plugin that provides access to a GraphQL API for numerical timeseries
data, general/tabular data, and annotations (thanks @retrodaredevil!).

Examples using GitHub API (using user's GitHub OAuth token):
* https://grafana.kmr.me/github-demo/d/N2Xxd_3Zz/security-advisories?orgId=1
* https://grafana.kmr.me/github-demo/d/u6O_F_qWk/repository?orgId=1

Example using Deutsche Bahn public timetable API to show train arrivals:
* https://grafana.kmr.me/github-demo/d/Z-cp4bqZk/db-arrivals?orgId=1

## Configuration

URL: https://bahnql.herokuapp.com/graphql

## Table with train number and platform

Query:

```
{
  station:stationWithEvaId(evaId: 8000105) {
    timetable {
      nextArrivals {
        Time:time
        trainNumber
        platform
      }
    }
  }
}
```

Data path: `station.timetable.nextArrivals`


## Annotations

Query and datapath same as above
Title: `$field_trainNumber`
Text: `Platform $field_platform`

## Screenshot

![image](https://user-images.githubusercontent.com/1627510/79922239-3c4d0f80-83f9-11ea-96b0-e53c1a30b5f8.png)
