### PR TITLE
add  datasource plugin  autohome-compareQueries-datasource.

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3897,7 +3897,7 @@
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "2344e7eee987e2c95fc204aaa3bf62c0f973545c",
+          "commit": "6482b51f4e24b6701e19218482bb23246d88aaaf",
           "url": "https://github.com/AutohomeCorp/autohome-compareQueries-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3889,6 +3889,18 @@
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]
+    },
+    {
+      "id": "autohome-compareQueries-datasource",
+      "type": "datasource",
+      "url": "https://github.com/AutohomeCorp/autohome-compareQueries-datasource",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "2344e7eee987e2c95fc204aaa3bf62c0f973545c",
+          "url": "https://github.com/AutohomeCorp/autohome-compareQueries-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
autohome-compareQueries-datasource is built as a datasource plugin that combines and contrasts different time shifts data.
