### PR TITLE
OpenNMS Helm 5.0.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -695,6 +695,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "5.0.2",
+          "commit": "5fc338fc0ef505b152518ec9cd39d552653908d5",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "5.0.1",
           "commit": "b1c7e0e78901ce46a32c8f5f4c28b36d8106e30d",
           "url": "https://github.com/OpenNMS/opennms-helm"

--- a/repo.json
+++ b/repo.json
@@ -695,6 +695,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "6.0.0",
+          "commit": "c93251b9ed0c344452be281b9a95c1fb1bf78ec6",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "5.0.3",
           "commit": "adf709157c0d1db9ba2c46622d6688f76f9d7d93",
           "url": "https://github.com/OpenNMS/opennms-helm"

--- a/repo.json
+++ b/repo.json
@@ -695,6 +695,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "5.0.3",
+          "commit": "adf709157c0d1db9ba2c46622d6688f76f9d7d93",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "5.0.2",
           "commit": "5fc338fc0ef505b152518ec9cd39d552653908d5",
           "url": "https://github.com/OpenNMS/opennms-helm"


### PR DESCRIPTION
This release contains significant documentation updates, as well as a few bug fixes including Grafana 6.7 support.
It also bumps the Grafana provided by our Docker images to `6.7.2`.

* Document how to use the filter panel (Issue [HELM-206](http://issues.opennms.org/browse/HELM-206))
* Document how to use the entity data-source (Issue [HELM-207](http://issues.opennms.org/browse/HELM-207))
* Publish build artifacts with CircleCI to Cloudsmith (Issue [HELM-214](http://issues.opennms.org/browse/HELM-214))
* Convert docs from Asciibinder to Antora (Issue [HELM-217](http://issues.opennms.org/browse/HELM-217))
* Integrate Antora documentation into CircleCI (Issue [HELM-218](http://issues.opennms.org/browse/HELM-218))
* Sign RPM and DEB packages with GPG key (Issue [HELM-222](http://issues.opennms.org/browse/HELM-222))
* Some filter could be documented (Issue [HELM-227](http://issues.opennms.org/browse/HELM-227))
* Cannot add an Alarm Table widget when using Grafana 6.6.x (Issue [HELM-229](http://issues.opennms.org/browse/HELM-229))
* Support Grafana 6.7.x for our Helm plugin (Issue [HELM-232](http://issues.opennms.org/browse/HELM-232))