### PR TITLE
Add Matomo Tracker panel

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4104,6 +4104,18 @@
       ]
     },
     {
+      "id": "thiagoarrais-matomotracking-panel",
+      "type": "panel",
+      "url": "https://github.com/thiagoarrais/grafana-matomo-tracking-panel",
+      "versions": [
+        {
+          "version": "0.2.2",
+          "commit": "1b334b8b0bd3b07909623dbdbdf560d969be0328",
+          "url": "https://github.com/thiagoarrais/grafana-matomo-tracking-panel"
+        }
+      ]
+    },
+    {
       "id": "grafana-strava-datasource",
       "type": "datasource",
       "url": "https://github.com/grafana/strava-datasource",


### PR DESCRIPTION
[Matomo](https://matomo.org/) is a web analytics platform. The Matomo Tracker panel is a Grafana Panel that allows Grafana Dashboards to be tracked by Matomo. It works much like a tracking pixel and is not intended to have any visible presence in the dashboard.

This plugin may help in https://github.com/grafana/grafana/issues/12234 and https://github.com/grafana/grafana/issues/3496

To setup a Matomo instance for testing, you can use the free Matomo hosted option. I've also achieved some success using [matomo-docker's nginx setup](https://github.com/matomo-org/docker/tree/master/.examples/nginx).