### PR TITLE
Update Multistat to v1.4.0 (Restyled tooltips and new Bar Links feature)

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3270,6 +3270,12 @@
           "version": "1.3.0",
           "commit": "195691d6cfc42b50ee55210d5bb2f418b046f0aa",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.4.0",
+          "commit": "c7e5624359fd8cf95f2b93d840cfa8155d6bd993",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3276,7 +3276,6 @@
           "commit": "c7e5624359fd8cf95f2b93d840cfa8155d6bd993",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
-        }
       ]
     },
     {


### PR DESCRIPTION
New bar-link feature with parameter substitution for intelligent drill downs.
Tested with Grafana v5.4.5 and Grafana 7-Beta 2
