### PR TITLE
Update Multistat to v1.4.0 (restyled tooltips and new Bar Links featu…

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3270,6 +3270,11 @@
           "version": "1.3.0",
           "commit": "195691d6cfc42b50ee55210d5bb2f418b046f0aa",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.4.0",
+          "commit": "c7e5624359fd8cf95f2b93d840cfa8155d6bd993",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]
     },


### PR DESCRIPTION
…re for drill-downs)

Releasing a new version (v1.4.0) of Multistat, with updated tooltip styling and clickable Bar Links feature.
Tested against Grafana 7-beta2 and Grafana 5.4.5
