### PR TITLE
Added Grafana LoudML plugin (1.7.1)

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4495,8 +4495,8 @@
       "url": "https://github.com/vsergeyev/loudml-grafana-app",
       "versions": [
         {
-          "version": "1.4.0",
-          "commit": "178be4f47ed6c370b781075f81357059a0f38255",
+          "version": "1.7.1",
+          "commit": "09373e79ed09a5bef228ed49a3be2ac934634323",
           "url": "https://github.com/vsergeyev/loudml-grafana-app"
     }
   ]

--- a/repo.json
+++ b/repo.json
@@ -3982,13 +3982,13 @@
       ]
     },
     {
-      "id": "grafana-loudml-app",
+      "id": "loudml-grafana-app",
       "type": "app",
       "url": "https://github.com/vsergeyev/loudml-grafana-app",
       "versions": [
         {
-          "version": "1.3.0",
-          "commit": "9f0575c97551acb464ac45123d6d48ebc1140270",
+          "version": "1.4.0",
+          "commit": "fb5bcf5790a1692200d5e2e47245e41201b2ace3",
           "url": "https://github.com/vsergeyev/loudml-grafana-app"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3980,6 +3980,18 @@
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]
+    },
+    {
+      "id": "grafana-loudml-app",
+      "type": "app",
+      "url": "https://github.com/vsergeyev/loudml-grafana-app",
+      "versions": [
+        {
+          "version": "1.3.0",
+          "commit": "9f0575c97551acb464ac45123d6d48ebc1140270",
+          "url": "https://github.com/vsergeyev/loudml-grafana-app"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -4498,6 +4498,8 @@
           "version": "1.7.1",
           "commit": "ff8b5de99afa7de7e7d8e361e055faeb63918055",
           "url": "https://github.com/vsergeyev/loudml-grafana-app"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -4496,7 +4496,7 @@
       "versions": [
         {
           "version": "1.7.1",
-          "commit": "09373e79ed09a5bef228ed49a3be2ac934634323",
+          "commit": "ff8b5de99afa7de7e7d8e361e055faeb63918055",
           "url": "https://github.com/vsergeyev/loudml-grafana-app"
     }
   ]


### PR DESCRIPTION
LoudML Grafana Application

Datasource and Graph panel visualization to connect with Loud ML Machine Learning server. 

Inside:
 * Loud ML Panel - is a version of Grafana's default Graph Panel with a "Create Baseline" button to create ML model in 1-click. Currently 1-click ML button ("Create Baseline") can produce model from: InfluxDB, OpenTSDB, Elasticsearch and Prometheus datasource.
 * Loud ML Datasource - is a connector to Loud ML server. It has capabilities to show models and jobs on server. You can add new and edit existing models.

Configuration: https://vsergeyev.github.io/loudml-grafana-app/
LoudML server docker setup: https://hub.docker.com/r/loudml/loudml

Regards,
V.