### PR TITLE
Update Multistat to v1.4.0 (restyled tooltips plus clickable bar-links for drilldowns)

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3278,7 +3278,7 @@
         },
         {
           "version": "1.4.0",
-          "commit": "c7e5624359fd8cf95f2b93d840cfa8155d6bd993",
+          "commit": "0fae84cc0252dae635974d9e04d8e498bb313626",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3278,7 +3278,7 @@
         },
         {
           "version": "1.4.0",
-          "commit": "b65fac7e2f1686f482cc802b7da7f89a22940c3e",
+          "commit": "13b3d1e4b627f07315952e2e1f75bcc987af76c0",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3278,7 +3278,7 @@
         },
         {
           "version": "1.4.0",
-          "commit": "13b3d1e4b627f07315952e2e1f75bcc987af76c0",
+          "commit": "20b6f3a04e49b32c8d3ca66796426eff83738f1b",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -3275,6 +3275,11 @@
           "version": "1.3.0",
           "commit": "195691d6cfc42b50ee55210d5bb2f418b046f0aa",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.4.0",
+          "commit": "c7e5624359fd8cf95f2b93d840cfa8155d6bd993",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3278,7 +3278,7 @@
         },
         {
           "version": "1.4.0",
-          "commit": "0fae84cc0252dae635974d9e04d8e498bb313626",
+          "commit": "b65fac7e2f1686f482cc802b7da7f89a22940c3e",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]


### PR DESCRIPTION
Re-requesting change after (stupidly) deleting my forked patch of repo.json which cancelled the earlier pull-request.  Duh!