### PR TITLE
adds akenza grafana connector to repo.json

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3985,6 +3985,18 @@
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]
+    },
+    {
+      "id": "akenza-grafana-connector",
+      "type": "datasource",
+      "url": "https://github.com/akenza-io/grafana-connector",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "0ece57bc54dc3fdfec4bb14a4ae5935c3e4d6627",
+          "url": "https://github.com/akenza-io/grafana-connector"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Purpose
The purpose of this plugin is to display IoT device data in Grafana which is captured and stored in the [Akenza Core](https://core.akenza.io). The Akenza Core is an IoT system which allows the management of IoT devices from a variety of different connectivity technologies.

## Testing the Plugin
In order to access the Akneza Core, an account has to be created [here](https://auth.akenza.io/register). Afterwards please contact me so I can add you to one of our workspaces which has already data from IoT devices in it (otherwise no really meaningful data could be tested). Once this is done, you can create an API Key and use it to view the device data.

The plugin can be tested using `yarn build` and afterwards `docker-compose up grafana` . This will spin up a local Grafana instance with the plugin already provided in it (default settings apply).

## Plugin Subscription
At the time of writing Akenza does not yet have a plugin subscription. However, we are planning to get one ASAP. This section will be updated accordingly once a plugin subscription has been purchased.
