### PR TITLE
zabbix plugin version 3.12.2

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -341,6 +341,11 @@
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
         {
+          "version": "3.12.2",
+          "commit": "793129b2d602b36b09dc64dab7ec6f5a6f7beb42",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix"
+        },
+        {
           "version": "3.12.1",
           "commit": "dc304e2040a9ffc1beec3f0cc8f6757bce4c5d47",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix"


### PR DESCRIPTION
Zabbix plugin update 3.12.2

## [3.12.2] - 2020-05-28
### Fixed
- Annotations feature doesn't work, [#964](https://github.com/alexanderzobnin/grafana-zabbix/issues/964)
- Alias variables do not work with direct DB connection enabled, [#965](https://github.com/alexanderzobnin/grafana-zabbix/issues/965)