### PR TITLE
Hourly heatmap panel v0.3.2

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4018,7 +4018,7 @@
       "versions": [
         {
           "version": "0.3.2",
-          "commit": "15613ab71cb3647ef7c3a4fc4a00a22e5e08040e",
+          "commit": "db8be3a7f122b3b4b9f66e402838af0e083532b9",
           "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4018,7 +4018,7 @@
       "versions": [
         {
           "version": "0.3.2",
-          "commit": "e5f4ae61fdd57e338ba81dfe9556621a13f03756",
+          "commit": "15613ab71cb3647ef7c3a4fc4a00a22e5e08040e",
           "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4018,7 +4018,7 @@
       "versions": [
         {
           "version": "0.3.2",
-          "commit": "db8be3a7f122b3b4b9f66e402838af0e083532b9",
+          "commit": "ca330878b6142d3657a08e22de41135c55f2b5d6",
           "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4010,6 +4010,18 @@
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]
+    },
+    {
+      "id": "marcusolsson-hourly-heatmap-panel",
+      "type": "panel",
+      "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel",
+      "versions": [
+        {
+          "version": "0.3.0",
+          "commit": "2b153a87c06019a6c9fc15a61b3ed130d07d4770",
+          "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -4017,8 +4017,8 @@
       "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel",
       "versions": [
         {
-          "version": "0.3.1",
-          "commit": "6692912ff91c1d66335761d0a8448e6a63b520f1",
+          "version": "0.3.2",
+          "commit": "e5f4ae61fdd57e338ba81dfe9556621a13f03756",
           "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4017,8 +4017,8 @@
       "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel",
       "versions": [
         {
-          "version": "0.3.0",
-          "commit": "2b153a87c06019a6c9fc15a61b3ed130d07d4770",
+          "version": "0.3.1",
+          "commit": "6692912ff91c1d66335761d0a8448e6a63b520f1",
           "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel"
         }
       ]


### PR DESCRIPTION
This introduces a panel for creating hourly heatmaps. 

The [carpetplot](https://github.com/petrslavotinek/grafana-carpetplot) plugin by @petrslavotinek is a widely used panel plugin, which unfortunately has not been maintained for the last 3 years.

This is designed to be a drop-in replacement for the carpet plot plugin, and can be tested in the same way, either use the TestDataDB, or Google Sheets to generate data.