### PR TITLE
Add REST Datasource v0.3.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3105,6 +3105,17 @@
       ]
     },
     {
+      "id": "pithikos-rest-datasource",
+      "type": "datasource",
+      "url": "https://github.com/Pithikos/rest-datasource",
+      "versions": [
+        {
+          "version": "0.3.1",
+          "commit": "6dd44bfd3d4bf940f4e7e56396e6abb190884959",
+          "url": "https://github.com/Pithikos/rest-datasource"
+        },
+    },
+    {
       "id": "simpod-json-datasource",
       "type": "datasource",
       "url": "https://github.com/simPod/grafana-json-datasource",

--- a/repo.json
+++ b/repo.json
@@ -3113,7 +3113,8 @@
           "version": "0.3.1",
           "commit": "6dd44bfd3d4bf940f4e7e56396e6abb190884959",
           "url": "https://github.com/Pithikos/rest-datasource"
-        },
+        }
+      ]
     },
     {
       "id": "simpod-json-datasource",


### PR DESCRIPTION
Installation

1. Add the datasource `rest-datasource`.
2. Add any REST endpoint for the `endpoint` setting.

Assuming we get the below payload

```json
{
  "userStats": {
    "totalUsers": 3,
    "userActivity":{
      "active": [1, 2, 5],
      "inactive": [2, 5, 3],
      "time": [1591718913418.654, 1591722913418.654, 1591723913418.654]
    }
  }
}
```

We can access the total users by using the key `userStats.totalUsers` and the user activity with `userStats.userActivity`.