### PR TITLE
New version of bubble chart

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2418,7 +2418,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "e86d545dcbb3cf63b4233ffb056de58e7f102c4d",
+          "commit": "297ebe0a171661086e25fca0f6afad9e49c4758a",
           "url": "https://github.com/digrich/bubblechart-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2418,7 +2418,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "8983071f6b1a3382602a21ec1ea6e310ec9f6323",
+          "commit": "e86d545dcbb3cf63b4233ffb056de58e7f102c4d",
           "url": "https://github.com/digrich/bubblechart-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2418,7 +2418,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "df8a4129bb4298f5d200696621a7e13ed9af9c01",
+          "commit": "e14aad17824bdd4c995514b0d94c5cd9532d5cc5",
           "url": "https://github.com/digrich/bubblechart-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2415,6 +2415,11 @@
           "version": "1.1.0",
           "commit": "0d2ee17f7dd7516affec5b1eca502d1bc1e2d212",
           "url": "https://github.com/digrich/bubblechart-panel"
+        },
+        {
+          "version": "1.2.0",
+          "commit": "8983071f6b1a3382602a21ec1ea6e310ec9f6323",
+          "url": "https://github.com/digrich/bubblechart-panel"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -12,7 +12,7 @@
         },
         {
           "version": "0.0.3",
-          "commit": "b5d087b8741334d85604206f9aaa2ca3d31fec79",
+          "commit": "b5d087b8741334d85604206f9aaa2ca3d31fec79", 
           "url": "https://github.com/BT-OpenSource/bt-grafana-trend-box"
         },
         {
@@ -2418,7 +2418,7 @@
         },
         {
           "version": "1.2.0",
-          "commit": "297ebe0a171661086e25fca0f6afad9e49c4758a",
+          "commit": "df8a4129bb4298f5d200696621a7e13ed9af9c01",
           "url": "https://github.com/digrich/bubblechart-panel"
         }
       ]


### PR DESCRIPTION
Please release the new version of bubble chart. It's having couple of bug fixes along with grafana > 6.6 compatibility.  