### PR TITLE
Added Grafana Thredds Plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4015,6 +4015,18 @@
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]
+    },
+    {
+      "id": "grafana-thredds-panel",
+      "type": "panel",
+      "url": "https://github.com/inkode-it/grafana-thredds-panel",
+      "versions": [
+        {
+          "version": "0.2.1",
+          "commit": "820b1d6a5cf7e45c2bd33f206dae89eb4db3531c",
+          "url": "https://github.com/inkode-it/grafana-thredds-panel"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This panel permits to map and query a WMS service from THREDDS DATA SERVER, no datasource is needed.
A default configuration is already provided