### PR TITLE
adding new plugin THREDDS panel

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -341,6 +341,11 @@
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
         {
+          "version": "3.12.2",
+          "commit": "793129b2d602b36b09dc64dab7ec6f5a6f7beb42",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix"
+        },
+        {
           "version": "3.12.1",
           "commit": "dc304e2040a9ffc1beec3f0cc8f6757bce4c5d47",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix"

--- a/repo.json
+++ b/repo.json
@@ -4033,7 +4033,7 @@
       "versions": [
         {
           "version": "0.2.1",
-          "commit": "751bc0beb2a08137c0b72880d0806ccd75a57983",
+          "commit": "e1d3a78a3b80294c2320c917ecc7eebff7cfdee2",
           "url": "https://github.com/inkode-it/thredds-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4033,7 +4033,7 @@
       "versions": [
         {
           "version": "0.2.1",
-          "commit": "6a8eb6da6ca8ed3cfabd6cd00557e88a2f252237",
+          "commit": "751bc0beb2a08137c0b72880d0806ccd75a57983",
           "url": "https://github.com/inkode-it/thredds-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4015,6 +4015,18 @@
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]
+    },
+    {
+      "id": "thredds-panel",
+      "type": "panel",
+      "url": "https://github.com/inkode-it/thredds-panel",
+      "versions": [
+        {
+          "version": "0.2.1",
+          "commit": "6a8eb6da6ca8ed3cfabd6cd00557e88a2f252237",
+          "url": "https://github.com/inkode-it/thredds-panel"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This panel permits to map and query a WMS service from THREDDS DATA SERVER, no datasource is needed.
A default configuration is already provided (only mapbox api token is required), this is a first but working version
