### PR TITLE
Update macropower-analytics-panel (v1.0.0)

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3938,6 +3938,16 @@
           "version": "0.0.1",
           "commit": "cf24374926a0ec2cbd63d87898a17532639185d0",
           "url": "https://github.com/MacroPower/macropower-analytics-panel"
+        },
+        {
+          "version": "0.0.3",
+          "commit": "80ebb6e26352d1718ea3ea7d4c54d714adf8fe73",
+          "url": "https://github.com/MacroPower/macropower-analytics-panel"
+        },
+        {
+          "version": "1.0.0",
+          "commit": "6fd3810d99fde01b76521d5a129d2e82134df244",
+          "url": "https://github.com/MacroPower/macropower-analytics-panel"
         }
       ]
     },


### PR DESCRIPTION
This PR updates macropower-analytics-panel to version 1.0.0, and also adds a reference to version 0.0.3.

1.0.0 is the current version, which now uses React and has a few new features. 0.0.3 was mainly a hotfix to fix a bug in Grafana 7. I would like to make both versions available in case there are any issues with 1.0.0.

If you would like to test the panel, you can run `npm run telegraf` to start a Telegraf container. This will print results to your console when the panel is loaded.

## [Changelog]

### 1.0.0:

- **Migrates plugin to React**
- Adds an option to toggle between normal and flattened data
- Displays errors on the panel when a fetch cannot be completed
- Adds TimeRange to/from to output as unix time
- Restructures the output data (*breaking for listeners that are strictly typed*)

### 0.0.3:

- **Fixes an issue where references were incorrect in Grafana 7**
- Adds support and documentation for Telegraf as an http listener
