### PR TITLE
Clickhouse Datasource plugin version update to 2.0.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2135,7 +2135,7 @@
         },
         {
           "version": "2.0.1",
-          "commit": "d8a3e2f3209d0f419fe939e3323ff1eaee346187",
+          "commit": "87c89b84d7d522dd04bb4b21c68c6665a0b9e458",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2127,6 +2127,11 @@
           "version": "1.9.5",
           "commit": "50d46ef5138f5b5d8098c1cbacc7f0d3f56e16a9",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "2.0.0",
+          "commit": "f60bdeac5aa45d43f2c9cdd186e160b855b0feca",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2132,6 +2132,11 @@
           "version": "2.0.0",
           "commit": "f60bdeac5aa45d43f2c9cdd186e160b855b0feca",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "2.0.1",
+          "commit": "d8a3e2f3209d0f419fe939e3323ff1eaee346187",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2135,7 +2135,7 @@
         },
         {
           "version": "2.0.1",
-          "commit": "87c89b84d7d522dd04bb4b21c68c6665a0b9e458",
+          "commit": "7b73be0ab0dbc2db2bb3897b57a68af667a5eee1",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]


### PR DESCRIPTION
# 2.0.1 (2020-06-19)
See release notes here: https://github.com/Vertamedia/clickhouse-grafana/releases/tag/2.0.1

## Fixes:
* fix golang alerts for $columns, $perSecond, $perSecondColumns macros https://github.com/Vertamedia/clickhouse-grafana/pull/200

# 2.0.0 (2020-06-17) 
See release notes here: https://github.com/Vertamedia/clickhouse-grafana/releases/tag/2.0.0

## Enhancements:
* compatibility with grafana 7.x, please use environment variable `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=vertamedia-clickhouse-datasource` or `allow_loading_unsigned_plugins=vertamedia-clickhouse-datasource` in plugins section of `grafana.ini` https://github.com/Vertamedia/clickhouse-grafana/pull/192
* add grafana 7.x alerting support thanks to Brian Thai https://github.com/bmanth60
* add alias support to $perSecondColumns macro https://github.com/Vertamedia/clickhouse-grafana/pull/193
* Support `custom` variable type and empty values for `$conditionalTest` macro https://github.com/Vertamedia/clickhouse-grafana/pull/178
* add docker-compose.yaml to improve local development

## Fixes:
* fix AST for corner case when quotes escaped inside quotes https://github.com/Vertamedia/clickhouse-grafana/pull/123, https://github.com/Vertamedia/clickhouse-grafana/pull/195
* fix https://github.com/Vertamedia/clickhouse-grafana/issues/179,  add "Extrapolation" checkbox to Query Editor