### PR TITLE
Add cloudspout-button-panel

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4113,39 +4113,6 @@
           "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel"
         }
       ]
-    },
-    {
-      "id": "marcusolsson-treemap-panel",
-      "type": "panel",
-      "url": "https://github.com/marcusolsson/grafana-treemap-panel",
-      "versions": [
-        {
-          "version": "0.1.0",
-          "commit": "f2ea6e9907a87bef6eb1a982d7ade3ff7cf16e75",
-          "url": "https://github.com/marcusolsson/grafana-treemap-panel"
-        }
-      ]
-    },
-    {
-      "id": "dalvany-image-panel",
-      "type": "panel",
-      "versions": [
-        {
-          "version": "2.0.0",
-          "commit": "342ccfaa188aef5112f067fad5317d0c9504a102",
-          "url": "https://github.com/Dalvany/dalvany-image-panel"
-        },
-        {
-          "version": "2.1.0",
-          "commit": "3063c83128315bd0b49b793fb9fa761751028f0c",
-          "url": "https://github.com/Dalvany/dalvany-image-panel"
-        },
-        {
-          "version": "2.1.1",
-          "commit": "68e400abc134b1e724c055b56074d8b6a5ffd467",
-          "url": "https://github.com/Dalvany/dalvany-image-panel"
-        }
-      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -4113,6 +4113,18 @@
           "url": "https://github.com/marcusolsson/grafana-hourly-heatmap-panel"
         }
       ]
+    },
+    {
+      "id": "cloudspout-button-panel",
+      "type": "panel",
+      "url": "https://github.com/cloudspout/cloudspout-button-panel/",
+      "versions": [
+        {
+          "version": "7.0.2",
+          "commit": "2611f522fd3e3fba2c9aea5990cdcf207e8d7889",
+          "url": "https://github.com/cloudspout/cloudspout-button-panel/"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -4115,6 +4115,18 @@
       ]
     },
     {
+      "id": "marcusolsson-treemap-panel",
+      "type": "panel",
+      "url": "https://github.com/marcusolsson/grafana-treemap-panel",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "commit": "f2ea6e9907a87bef6eb1a982d7ade3ff7cf16e75",
+          "url": "https://github.com/marcusolsson/grafana-treemap-panel"
+        }
+      ]
+    },
+    {
       "id": "cloudspout-button-panel",
       "type": "panel",
       "url": "https://github.com/cloudspout/cloudspout-button-panel/",
@@ -4123,6 +4135,27 @@
           "version": "7.0.3",
           "commit": "b4b31939068a5c2fe1e67514fcaa34e43ca28f5c",
           "url": "https://github.com/cloudspout/cloudspout-button-panel/"
+        }
+      ]
+    },
+    {
+      "id": "dalvany-image-panel",
+      "type": "panel",
+      "versions": [
+        {
+          "version": "2.0.0",
+          "commit": "342ccfaa188aef5112f067fad5317d0c9504a102",
+          "url": "https://github.com/Dalvany/dalvany-image-panel"
+        },
+        {
+          "version": "2.1.0",
+          "commit": "3063c83128315bd0b49b793fb9fa761751028f0c",
+          "url": "https://github.com/Dalvany/dalvany-image-panel"
+        },
+        {
+          "version": "2.1.1",
+          "commit": "68e400abc134b1e724c055b56074d8b6a5ffd467",
+          "url": "https://github.com/Dalvany/dalvany-image-panel"
         }
       ]
     }

--- a/repo.json
+++ b/repo.json
@@ -4120,8 +4120,8 @@
       "url": "https://github.com/cloudspout/cloudspout-button-panel/",
       "versions": [
         {
-          "version": "7.0.2",
-          "commit": "2611f522fd3e3fba2c9aea5990cdcf207e8d7889",
+          "version": "7.0.3",
+          "commit": "b4b31939068a5c2fe1e67514fcaa34e43ca28f5c",
           "url": "https://github.com/cloudspout/cloudspout-button-panel/"
         }
       ]


### PR DESCRIPTION
Please consider adding cloudspout-button-panel to the plugin repository.

It provides a simple panel that shows only one button - to integrate with any kind of HTTP/REST API:
* Support GET and POST HTTP verb
    * Adds no new javascript dependencies
    * Uses standard browser APIs and respects CORS
* Support API key via header X-API-Key or query parameter ?api-key
* Custom label text & Grafana template design
