### PR TITLE
Update DevOpsProdigy KubeGraf App version to v1.4.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3912,6 +3912,11 @@
           "version": "1.4.0",
           "commit": "3da96b7b6e364d06e2752f1082f1e5791af4a840",
           "url": "https://github.com/devopsprodigy/kubegraf"
+        },
+        {
+          "version": "1.4.1",
+          "commit": "6e5e58e231f60b2b6136a9a6626453a7e7596475",
+          "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]
     },


### PR DESCRIPTION
**Bug Fixes**
- Fix integration nodes' metrics with different node-exporter installations