### PR TITLE
Add traceroute-map-panel plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4355,7 +4355,7 @@
       ]
     },
     {
-      "id": "gowee-traceroute-map-panel",
+      "id": "gowee-traceroutemap-panel",
       "type": "panel",
       "url": "https://github.com/Gowee/traceroute-map-panel",
       "versions": [

--- a/repo.json
+++ b/repo.json
@@ -4362,13 +4362,7 @@
         {
           "version": "0.2.0",
           "commit": "54f5074585e6f0df323331ddfb5d6968bfa97f8d",
-          "url": "https://github.com/Gowee/traceroute-map-panel",
-          "download": {
-            "any": {
-              "url": "https://github.com/Gowee/traceroute-map-panel/releases/download/v0.2.0/dist-v0.2.0.tar.gz",
-              "md5": "b0c8c8d72f24221f885f0191c36364de"
-            }
-          }
+          "url": "https://github.com/Gowee/traceroute-map-panel"
         }
       ]
     }

--- a/repo.json
+++ b/repo.json
@@ -4361,7 +4361,7 @@
       "versions": [
         {
           "version": "0.2.3",
-          "commit": "3cf79f049454db11da8b414d3cc10ea8aa9d9863",
+          "commit": "6b9a0e5560513c748deebe883418b8c683ea5a2d",
           "url": "https://github.com/Gowee/traceroute-map-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4361,7 +4361,7 @@
       "versions": [
         {
           "version": "0.2.3",
-          "commit": "6b9a0e5560513c748deebe883418b8c683ea5a2d",
+          "commit": "c19a7206c7c441823bff0bc435750348a4042a8e",
           "url": "https://github.com/Gowee/traceroute-map-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4360,8 +4360,8 @@
       "url": "https://github.com/Gowee/traceroute-map-panel",
       "versions": [
         {
-          "version": "0.2.0",
-          "commit": "7167ef1896b942c07fbf7cddbdd9f4b597177e2a",
+          "version": "0.2.2",
+          "commit": "d0ff30a71a1101f1a1c4e9f55ba75d3fb51f02ce",
           "url": "https://github.com/Gowee/traceroute-map-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4361,7 +4361,7 @@
       "versions": [
         {
           "version": "0.2.3",
-          "commit": "62fdd8331edafee944f1d00aca3b357940e818fd",
+          "commit": "3cf79f049454db11da8b414d3cc10ea8aa9d9863",
           "url": "https://github.com/Gowee/traceroute-map-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4361,7 +4361,7 @@
       "versions": [
         {
           "version": "0.2.0",
-          "commit": "54f5074585e6f0df323331ddfb5d6968bfa97f8d",
+          "commit": "7167ef1896b942c07fbf7cddbdd9f4b597177e2a",
           "url": "https://github.com/Gowee/traceroute-map-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4360,8 +4360,8 @@
       "url": "https://github.com/Gowee/traceroute-map-panel",
       "versions": [
         {
-          "version": "0.2.2",
-          "commit": "d0ff30a71a1101f1a1c4e9f55ba75d3fb51f02ce",
+          "version": "0.2.3",
+          "commit": "62fdd8331edafee944f1d00aca3b357940e818fd",
           "url": "https://github.com/Gowee/traceroute-map-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4361,7 +4361,7 @@
       "versions": [
         {
           "version": "0.2.3",
-          "commit": "c19a7206c7c441823bff0bc435750348a4042a8e",
+          "commit": "a59eb13ec63150a1478c325ba976f47bd37b0902",
           "url": "https://github.com/Gowee/traceroute-map-panel"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4353,6 +4353,24 @@
           "url": "https://github.com/fifemon/graphql-datasource"
         }
       ]
+    },
+    {
+      "id": "gowee-traceroute-map-panel",
+      "type": "panel",
+      "url": "https://github.com/Gowee/traceroute-map-panel",
+      "versions": [
+        {
+          "version": "0.2.0",
+          "commit": "54f5074585e6f0df323331ddfb5d6968bfa97f8d",
+          "url": "https://github.com/Gowee/traceroute-map-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/Gowee/traceroute-map-panel/releases/download/v0.2.0/dist-v0.2.0.tar.gz",
+              "md5": "b0c8c8d72f24221f885f0191c36364de"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hello.

This panel plugin helps visualize traceroute hops on a map as is shown in the [README](https://github.com/Gowee/traceroute-map-panel).

I build this project based upon https://github.com/grafana/simple-react-panel and have checked the relevant guidelines. But I am not sure if everything will go well because the new and legacy documents seems a little messy to me. Please let me know if there is something wrong.

Thanks.