### PR TITLE
Update KubeGraf version to v1.4.2

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3983,6 +3983,11 @@
           "version": "1.4.1",
           "commit": "6e5e58e231f60b2b6136a9a6626453a7e7596475",
           "url": "https://github.com/devopsprodigy/kubegraf"
+        },
+        {
+          "version": "1.4.2",
+          "commit": "dd00d1b7570c2f012e6fde1c734f51e5cf6f16c0",
+          "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]
     },


### PR DESCRIPTION
### Bug Fixes
* Compatibility with Grafana >= 7.0.4 [#35](https://github.com/devopsprodigy/kubegraf/issues/35)
* Restore metrics from old/deleted pods to dashboards [#33](https://github.com/devopsprodigy/kubegraf/issues/33)