### PR TITLE
Zabbix plugin version 3.12.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -341,6 +341,11 @@
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
         {
+          "version": "3.12.3",
+          "commit": "f84232e9c82f494d4c488c7d628c54ef30d84551",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix"
+        },
+        {
           "version": "3.12.2",
           "commit": "793129b2d602b36b09dc64dab7ec6f5a6f7beb42",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix"


### PR DESCRIPTION
Zabbix plugin 3.12.3

## [3.12.3] - 2020-07-17
### Fixed
- Problems: empty problem list, [#955](https://github.com/alexanderzobnin/grafana-zabbix/issues/955)