### PR TITLE
Update Multistat to 1.4.1 to fix bug with Grafana 7.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3356,6 +3356,11 @@
           "version": "1.4.0",
           "commit": "20b6f3a04e49b32c8d3ca66796426eff83738f1b",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.4.1",
+          "commit": "eb7c20fe699a0cbb84a6e37a8039ec7bfca9afb8",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
         }
       ]
     },


### PR DESCRIPTION
Grafana 7.1 removed support for the variableSvr injection parameter in the constructor, breaking this and presumably other panels built under the Angular model.

This release also updates the event mechanism (removing the named events warning) and adds a new 'sum' aggregation variant,a s requested by users.

**This is an urgent fix**

