### PR TITLE
Add williamvenner-timepickerbuttons-panel

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4265,6 +4265,18 @@
           "url": "https://github.com/Clarity-89/grafana-finnhub"
         }
       ]
+    },
+    {
+      "id": "williamvenner-timepickerbuttons-panel",
+      "type": "panel",
+      "url": "https://github.com/WilliamVenner/grafana-timepicker-buttons",
+      "versions": [
+        {
+          "version": "1.1.0",
+          "commit": "e3c1178f7b0bab8eab86745d6e8be4836ad117da",
+          "url": "https://github.com/WilliamVenner/grafana-timepicker-buttons"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Validated with the plugin validator app.

Previous PR: https://github.com/grafana/grafana-plugin-repository/pull/473

Awesome validator by the way, very useful. It caches this error, though:

![image](https://user-images.githubusercontent.com/14863743/89918336-ce1f9900-dbf1-11ea-8b01-38d5438d2252.png)

(I have [an account with this username](https://grafana.com/orgs/williamvenner) now)