### PR TITLE
Add QuestDB datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4582,6 +4582,18 @@
           "url": "https://github.com/innius/grafana-video-panel"
         }
       ]
+    },
+    {
+      "id": "questdb-datasource",
+      "type": "datasource",
+      "url": "https://github.com/questdb/grafana-datasource",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "commit": "01b0f2053426e2515a5c59cc1704b70578e9a9b6",
+          "url": "https://github.com/questdb/grafana-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hi Grafana team,

This PR adds a new datasource plugin for [questdb.io](questdb.io) (or [GitHub link](https://github.com/questdb/questdb)).

To test the plugin, you can run QuestDB in Docker with:

```shell
docker run -p 9000:9000 questdb/questdb
```

If you need to add data, you can:

1. Go to the Web Console at http://localhost:9000/
2. Run the query:

```sql
CREATE TABLE test AS(
    SELECT cast(timestamp_sequence(dateadd('h', -6, systimestamp()), 100000000L) as timestamp) ts, x as value
    FROM long_sequence(500)
) timestamp(ts);
```