### PR TITLE
Zabbix plugin v4.0.0 with backend

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -341,6 +341,11 @@
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
         {
+          "version": "4.0.0",
+          "commit": "227f580a0343eee23e1476e8ff0b1b11bb1c18f2",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix"
+        },
+        {
           "version": "3.12.4",
           "commit": "309146fa6b001dc776acb250b8668eeac2db4f92",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix"

--- a/repo.json
+++ b/repo.json
@@ -342,8 +342,13 @@
       "versions": [
         {
           "version": "4.0.0",
-          "commit": "227f580a0343eee23e1476e8ff0b1b11bb1c18f2",
-          "url": "https://github.com/alexanderzobnin/grafana-zabbix"
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix",
+          "download": {
+            "any": {
+              "url": "https://github.com/alexanderzobnin/grafana-zabbix/releases/download/v4.0.0/grafana-zabbix-4.0.0.zip",
+              "md5": "411888fc2793d7ba69f19bd2a34bf0f1"
+            }
+          }
         },
         {
           "version": "3.12.4",


### PR DESCRIPTION
Stable release of zabbix plugin 4.0. Available through the github release.