### PR TITLE
Update Redis Datasource 1.2.0 with signing

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4343,6 +4343,11 @@
           "version": "1.1.1",
           "commit": "0d79ba96fd6febca54d727391781e586230958ba",
           "url": "https://github.com/RedisTimeSeries/grafana-redis-datasource"
+        },
+        {
+          "version": "1.2.0",
+          "commit": "d05843bdb268bbbf0b0b933d7ffaebfab66a7084",
+          "url": "https://github.com/RedisTimeSeries/grafana-redis-datasource"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4347,7 +4347,13 @@
         {
           "version": "1.2.0",
           "commit": "d05843bdb268bbbf0b0b933d7ffaebfab66a7084",
-          "url": "https://github.com/RedisTimeSeries/grafana-redis-datasource"
+          "url": "https://github.com/RedisTimeSeries/grafana-redis-datasource",
+          "download": {
+            "any": {
+              "url": "https://storage.googleapis.com/plugins-community/redis-datasource/release/1.2.0/redis-datasource-1.2.0.zip",
+              "md5": "db046e55c50ae6bd70c04b82516718b9"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
@briangann Please review and let me know if you have any questions.

- Added docker cmd line option to start in README #31
- How to query a specific database inside the same Redis single node #34
- Update docker-compose to load datasource from the repository and add development file #39
- Use "ScopedVars" when applying template variables #37
- Refactoring to support new commands and modules #42
- Add support for TS.GET, TS.INFO, and TS.QUERYINDEX commands #45
- Add Redis dashboard to support multiple Redis instances #49
- Plugin executable missing for arm64 architecture #48 (Grafana SDK: grafana/grafana-plugin-sdk-go#221)
- Return 0 for all buckets with 0 counts on time-series TS.RANGE queries #50
- Add Redis Cluster support and update monitoring dashboard #52
- Connection issue to Redis deployed in k8s (Sentinel) #38
- MRANGE: add fill zero option #53
- Add Streaming capabilities to visualize INFO command #57
- Slowlog returns 'No data' for Redis 3.0.6 #33
- Fix backend lint issues #41
- ts.mrange returns no data when label has spaces within #44

![Screen Shot 2020-08-26 at 11 12 07 PM](https://user-images.githubusercontent.com/47795110/91406369-1a282b80-e7f7-11ea-8149-f74188a8b385.png)
