### PR TITLE
Adding Sensu Go data source

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4478,6 +4478,18 @@
           "url": "https://github.com/Dikshita25/sunburst-grafana-plugin"
         }
       ]
+    },
+    {
+      "id": "sensu-sensugo-datasource",
+      "type": "datasource",
+      "url": "https://github.com/sensu/grafana-sensu-go-datasource",
+      "versions": [
+        {
+          "version": "1.1.0",
+          "commit": "95373f26b9f839db21278f4ef5fd0130832b3ebc",
+          "url": "https://github.com/sensu/grafana-sensu-go-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hi Grafana-Team,

this PR is adding a data source for [Sensu Go](https://sensu.io/).

You can easily create an environment for testing the data source by the following steps using Sensu Go's Docker components (it's basically a copy of the test setup described on its website):

1. Install Sensu Go (backend and an agent in order to get some data)
```
$ sudo docker network create sensu
$ sudo docker volume create sensu-backend-data
$ sudo docker run -d --rm --name sensu-backend \
  --network sensu -p 8080:8080 -p 3000:3000 \
  -v sensu-backend-data:/var/lib/sensu \
  sensu/sensu:6.0.0 sensu-backend start
11bbb27c3
$ sudo docker run -d --rm --network sensu -p :3030 \
  sensu/sensu:6.0.0 sensu-agent start \
  --backend-url ws://sensu-backend:8081 --deregister \
  --keepalive-interval=5 --keepalive-warning-timeout=10 --subscriptions linux
$ curl -s http://localhost:8080/version
{"etcd":{"etcdserver":"3.3.13","etcdcluster":"3.3.0"},"sensu_backend":"6.0.0"}
$ _
```

2. Install the Sensu Go CLI (required for adding some sample check which we'll see in Grafana)
```
$ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.0.0/sensu-go_6.0.0_linux_amd64.tar.gz
$ sudo tar -xzf sensu-go_6.0.0_linux_amd64.tar.gz -C /usr/local/bin/
$ sensuctl configure -n --url http://127.0.0.1:8080 \
  --username admin \
  --password "P@ssw0rd!" \
  --namespace default
$ sensuctl cluster health
ID                NAME     ERROR   HEALTHY
8927110dc66458af  default          true
$ sensuctl cluster id
sensu cluster id: "227b26eb-26c4-46b2-bc7c-8c080b072e6b"
$ _
```

3. Configure a monitor
```
$ sensuctl asset add sensu/monitoring-plugins:2.2.0-1
fetching bonsai asset: sensu/monitoring-plugins:2.2.0-1
added asset: sensu/monitoring-plugins:2.2.0-1
$ sensuctl check create ntp \
  --runtime-assets "sensu/monitoring-plugins" \
  --command "check_ntp_time -H time.nist.gov --warn 0.5 --critical 1.0" \
  --output-metric-format nagios_perfdata \
  --publish="true" --interval 30 --timeout 10 --subscriptions linux
$ sensuctl event list
ENTITY        CHECK      OUTPUT                                                                    STATUS  SILENCED   TIMESTAMP
a749e3a10d86  keepalive  Keepalive last sent from a749e3a10d86 at 2019-09-11 15:34:25 +0000 UTC    0       false      2019-09-11 08:34:25 -0700 PDT
a749e3a10d86  ntp        NTP OK: Offset -0.03375908732 secs|offset=-0.033759s;0.500000;1.000000;   0       false      2019-09-11 08:34:22 -0700 PDT
$ _
```