### PR TITLE
Zabbix plugin v4.0.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -367,11 +367,11 @@
         {
           "version": "4.0.1",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix",
-          "commit": "a0d57ee8d1e07756bf7248411fdf00536368df52",
+          "commit": "95aee8f0488eb87b0c061f234f815e0e11f6f129",
           "download": {
             "any": {
               "url": "https://github.com/alexanderzobnin/grafana-zabbix/releases/download/v4.0.1/alexanderzobnin-zabbix-app-4.0.1.zip",
-              "md5": "9120fa38d5bec810758c44c356942974"
+              "md5": "24f92c7c4ee898a0bdaedc9a17718e0a"
             }
           }
         },

--- a/repo.json
+++ b/repo.json
@@ -365,6 +365,17 @@
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
         {
+          "version": "4.0.1",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix",
+          "commit": "a0d57ee8d1e07756bf7248411fdf00536368df52",
+          "download": {
+            "any": {
+              "url": "https://github.com/alexanderzobnin/grafana-zabbix/releases/download/v4.0.1/alexanderzobnin-zabbix-app-4.0.1.zip",
+              "md5": "9120fa38d5bec810758c44c356942974"
+            }
+          }
+        },
+        {
           "version": "4.0.0",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix",
           "commit": "eda67fdf687c0105d9555d50c8bf6bb482a5aab1",


### PR DESCRIPTION
Patch release for zabbix plugin. Now it's signed.

## [4.0.1] - 2020-09-02
### Fixed
- Plugin is not signed, [#1038](https://github.com/alexanderzobnin/grafana-zabbix/issues/1038)
- Datasource: "Parse error Invalid JSON. An error occurred on the server while parsing the JSON text", [#1004](https://github.com/alexanderzobnin/grafana-zabbix/issues/1004)
- Datasource: Skip TLS Verify button does not work, [#1029](https://github.com/alexanderzobnin/grafana-zabbix/issues/1029)
- Config: can't select Direct DB Connection in Grafana 7.1.5, [#1027](https://github.com/alexanderzobnin/grafana-zabbix/issues/1027)
- Problems: trigger dependencies not resolved, [#1024](https://github.com/alexanderzobnin/grafana-zabbix/issues/1024)