### PR TITLE
Add groonga-datasource 1.1.4

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4970,6 +4970,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "groonga-datasource",
+      "type": "datasource",
+      "url": "https://github.com/groonga/grafana-datasource-plugin-groonga",
+      "versions": [
+	{
+	  "version": "1.1.4",
+	  "commit": "d38efc809f84606b9a8343bc9b082733a4a23132",
+	  "url": "https://github.com/groonga/grafana-datasource-plugin-groonga",
+	  "download": {
+	    "any": {
+	      "url": "https://github.com/groonga/grafana-datasource-plugin-groonga/releases/download/1.1.4/groonga-datasource-1.1.4.zip",
+	      "md5": "f4fb0862c4c9a68f0cb07957117ee4d2"
+	    }
+	  }
+	}
+      ]
     }
   ]
 }


### PR DESCRIPTION
You can try groonga-datasource plugin with docker-compose:

From https://github.com/groonga/grafana-datasource-plugin-groonga#how-to-try :

Here are command lines to try groonga-datasource 1.1.4:

```bash
git clone https://github.com/groonga/grafana-datasource-plugin-groonga.git
cd grafana-datasource-plugin-groonga
GF_GROONGA_DATASOURCE_DIR=/tmp/groonga-datasource \
  GF_INSTALL_PLUGINS="https://github.com/groonga/grafana-datasource-plugin-groonga/releases/download/1.1.4/groonga-datasource-1.1.4.zip;groonga-datasource" \
  docker-compose up grafana
```

You can find Grafana at http://localhost:3000/ .

You can login as the `admin` user with `admin` for password.

You can find "Groonga" datasource at the bottom of
http://localhost:3000/datasources/new . You can use the following
parameters to use the test Groonga server that has some test data:

  * HTTP
    * URL: `http://groonga:10041/`
  * Groonga Details
    * Time field name: `timestamp`

You can use the Groonga datasource in a panel with the following
parameters:

  * Table Name: `Logs`

You can see visualized data in the test Groonga server.
