### PR TITLE
Add Innius datasource for Grafana

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4582,6 +4582,18 @@
           "url": "https://github.com/innius/grafana-video-panel"
         }
       ]
+    },
+    {
+      "id": "innius-datasource",
+      "type": "datasource",
+      "url": "https://github.com/innius/grafana-datasource-plugin",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "e91df0bcee3b96ca47aab9a987698659e3731f19",
+          "url": "https://github.com/innius/grafana-datasource-plugin"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -4590,7 +4590,7 @@
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "e91df0bcee3b96ca47aab9a987698659e3731f19",
+          "commit": "5a195515d8813277e0efcb79d2ed0c1972c263be",
           "url": "https://github.com/innius/grafana-datasource-plugin"
         }
       ]


### PR DESCRIPTION
Hello,

I created a new data source for Grafana which is configured for three environments (test, demo, and production). The production environment is not ready for now and we want to publish the plugin in a Beta version.

I will attach here an API key for the test environment: VktVQ3VDTlBTMWFacUdRTEhuR1JrUS5mbnc3VHpIYUJFZzd4SXByb2paNEZ3PT0=

Thank you