### PR TITLE
criteo-static-variables-datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4582,6 +4582,18 @@
           "url": "https://github.com/innius/grafana-video-panel"
         }
       ]
+    },
+    {
+      "id": "criteo-static-variables-datasource",
+      "type": "datasource",
+      "url": "https://github.com/criteo/grafana-static-variables-datasource",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "commit": "711bbe2db9b12c650ddf2b32796f68879000581c",
+          "url": "https://github.com/criteo/grafana-static-variables-datasource"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This is a plugin to manage static configuration to feed dashboard variables.

Simple and easy to use :
 1. Define queries and value as a simple as a Map<string,string[]> in JSON in the datasource configuration.
 2. Query the data from the dashboard variable configuration.

It plays very nicely with the new value groups/tags feature.