### PR TITLE
Clean Instana datasource versions > 2.7.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2940,6 +2940,11 @@
           "url": "https://github.com/instana/instana-grafana-datasource"
         },
         {
+          "version": "2.7.4",
+          "commit": "03b16c95075ed95a427153deed0c62a1155d6d6e",
+          "url": "https://github.com/instana/instana-grafana-datasource"
+        },
+        {
           "version": "3.0.0",
           "commit": "e01d51d5876037a10e57c7ceb60a14a868936975",
           "url": "https://github.com/instana/instana-grafana-datasource"
@@ -2947,6 +2952,11 @@
         {
           "version": "3.0.1",
           "commit": "b5c6a5140bf9d9e052f3b2bc9ba35e0cce047226",
+          "url": "https://github.com/instana/instana-grafana-datasource"
+        },
+        {
+          "version": "3.1.0",
+          "commit": "dd6a44554f50afc2d96c22417bb832281e356461",
           "url": "https://github.com/instana/instana-grafana-datasource"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2938,26 +2938,6 @@
           "version": "2.7.3",
           "commit": "caee8728cf5a389fd3795fab88a3fec9e118ed03",
           "url": "https://github.com/instana/instana-grafana-datasource"
-        },
-        {
-          "version": "2.7.4",
-          "commit": "03b16c95075ed95a427153deed0c62a1155d6d6e",
-          "url": "https://github.com/instana/instana-grafana-datasource"
-        },
-        {
-          "version": "3.0.0",
-          "commit": "e01d51d5876037a10e57c7ceb60a14a868936975",
-          "url": "https://github.com/instana/instana-grafana-datasource"
-        },
-        {
-          "version": "3.0.1",
-          "commit": "b5c6a5140bf9d9e052f3b2bc9ba35e0cce047226",
-          "url": "https://github.com/instana/instana-grafana-datasource"
-        },
-        {
-          "version": "3.1.0",
-          "commit": "dd6a44554f50afc2d96c22417bb832281e356461",
-          "url": "https://github.com/instana/instana-grafana-datasource"
         }
       ]
     },


### PR DESCRIPTION
As preparation for #750 we are going to remove 3.x versions to release an fix for the angular plugin (2.7.4)
the above mentioned pr will re-add the existing versions and add both new ones: 2.7.4, 3.0.0, 3.0.1, 3.1.0