### PR TITLE
Updating cloudspout-button-panel to version 7.0.23

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4515,12 +4515,12 @@
           "url": "https://github.com/cloudspout/cloudspout-button-panel/"
         },
         {
-          "version": "7.0.22",
+          "version": "7.0.23",
           "url": "https://github.com/cloudspout/cloudspout-button-panel/",
           "download": {
             "any": {
-              "url": "https://github.com/cloudspout/cloudspout-button-panel/releases/download/7.0.22/cloudspout-button-panel.zip",
-              "md5": "2a82a13c394072b674986b88073c9776"
+              "url": "https://github.com/cloudspout/cloudspout-button-panel/releases/download/7.0.23/cloudspout-button-panel.zip",
+              "md5": "96f71b9155545e6829be85984357cef7"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -4513,6 +4513,16 @@
           "version": "7.0.4",
           "commit": "0bdb76f61219a1ec515118fb49bff869d6867d5f",
           "url": "https://github.com/cloudspout/cloudspout-button-panel/"
+        },
+        {
+          "version": "7.0.22",
+          "url": "https://github.com/cloudspout/cloudspout-button-panel/",
+          "download": {
+            "any": {
+              "url": "https://github.com/cloudspout/cloudspout-button-panel/releases/download/7.0.22/cloudspout-button-panel.zip",
+              "md5": "2a82a13c394072b674986b88073c9776"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
The new version includes
* Allowing to specify a (POST) payload
* Customize button beyond what is provided by Grafana's button variants
* Tested support for Grafana 7.0.x - 7.3.x
* Signed plugin

It also uses the Grafana API `setPanelOptions` instead of the deprecated methods for better support of various Grafana versions.
