### PR TITLE
Add perfcurve-panel v1.3.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6,13 +6,13 @@
       "url": "https://github.com/SSKGo/perfcurve-panel",
       "versions": [
         {
-          "version": "1.3.0",
-          "commit": "d4393454b0a648f3b38a1d107656a6c98ea657ea",
+          "version": "1.3.1",
+          "commit": "ee787e3c22672afc48d1bc42ef8f8c9df2024156",
           "url": "https://github.com/SSKGo/perfcurve-panel",
           "download": {
             "any": {
-              "url": "https://github.com/SSKGo/perfcurve-panel/releases/download/v.1.3.0/sskgo-perfcurve-panel-1.3.0.zip",
-              "md5": "8ea6caf00be662e8e10c5389ddba623b"
+              "url": "https://github.com/SSKGo/perfcurve-panel/releases/download/v1.3.1/sskgo-perfcurve-panel-1.3.1.zip",
+              "md5": "4fb0c610e5a1c7ba1d0ca8549fbde2ef"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -6,9 +6,15 @@
       "url": "https://github.com/SSKGo/perfcurve-panel",
       "versions": [
         {
-          "version": "1.2.2",
-          "commit": "28ded416349918ce3c1e961cbb1c4765b3dbb7e0",
-          "url": "https://github.com/SSKGo/perfcurve-panel"
+          "version": "1.3.0",
+          "commit": "d4393454b0a648f3b38a1d107656a6c98ea657ea",
+          "url": "https://github.com/SSKGo/perfcurve-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/SSKGo/perfcurve-panel/releases/download/v.1.3.0/sskgo-perfcurve-panel-1.3.0.zip",
+              "md5": "8ea6caf00be662e8e10c5389ddba623b"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -1,6 +1,18 @@
 {
   "plugins": [
     {
+      "id": "sskgo-perfcurve-panel",
+      "type": "panel",
+      "url": "https://github.com/SSKGo/perfcurve-panel",
+      "versions": [
+        {
+          "version": "1.2.2",
+          "commit": "28ded416349918ce3c1e961cbb1c4765b3dbb7e0",
+          "url": "https://github.com/SSKGo/perfcurve-panel"
+        }
+      ]
+    },
+    {
       "id": "isaozler-paretochart-panel",
       "type": "panel",
       "url": "https://github.com/isaozler/pareto-chart",


### PR DESCRIPTION
Please review perfcurve-panel plugin.
If you have any questions, please let me know it.
- Initial release to register the plugin.
- Perfcurve panel plugin allow users to plot rotating machine operation point on a performance curve.
- The validation results by the plugin validator is as below.

![image](https://user-images.githubusercontent.com/54466390/96323011-50936180-1056-11eb-8c2f-779966dddc26.png)
