### PR TITLE
add Flowhook 0.1.2

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4637,6 +4637,18 @@
           "url": "https://github.com/innius/grafana-video-panel"
         }
       ]
+    },
+    {
+      "id": "verticle-flowhook-datasource",
+      "type": "datasource",
+      "url": "https://github.com/verticle-io/flowhook-datasource",
+      "versions": [
+        {
+          "version": "0.1.1",
+          "commit": "f1991dd781af3b57d5c8d72158c85076c6fa3df6",
+          "url": "https://github.com/verticle-io/flowhook-datasource"
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -4692,7 +4692,7 @@
           "download": {
             "any": {
               "url": "https://github.com/verticle-io/flowhook-datasource/releases/download/v0.1.2/verticle-flowhook-datasource-0.1.2.zip",
-              "md5": "d4ea628861ea1369e332ce38ad22d11a"
+              "md5": "7a391a15d021733483b3041ec4a83245"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -4688,7 +4688,13 @@
         {
           "version": "0.1.2",
           "commit": "b2a7f892aa4f11754b0034bec554001f3f20bb79",
-          "url": "https://github.com/verticle-io/flowhook-datasource"
+          "url": "https://github.com/verticle-io/flowhook-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/verticle-io/flowhook-datasource/releases/download/v0.1.2/verticle-flowhook-datasource-0.1.2.zip",
+              "md5": "d4ea628861ea1369e332ce38ad22d11a"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
PR for adding new datasource plugin for Flowhook integration.
The plugin allows to consume webhook payloads, map and route them into your Grafana Logs panel.

**Testing notes:**
The plugin can be tested by creating a small webhook mapping at https://flowhook.herokuapp.com which is currently released simultaneously.

1. Please follow the instructions and copy the generated Flowhook ID to the plugin config after installation. Other settings can be left as default.

2. Visualize the datasource using the standard Logs panel.

3. When config is done, go to the explorer and in parallel fire a couple of webhook requests. The mapped extract of the webhook payload should show up in the panel.
