### PR TITLE
Updated Alexandra-trackmap-panel to version 2.1.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4099,6 +4099,11 @@
           "version": "1.2.5",
           "commit": "4710fe0c8327750e8ba07c9d6293c70abef446cd",
           "url": "https://github.com/alexandrainst/alexandra-trackmap-panel"
+        },
+        {
+          "version": "2.0.0",
+          "commit": "8fd2758ec4c2562c2dea27b2f9f530cca141cbb4",
+          "url": "https://github.com/alexandrainst/alexandra-trackmap-panel"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4160,6 +4160,11 @@
           "version": "2.0.0",
           "commit": "8fd2758ec4c2562c2dea27b2f9f530cca141cbb4",
           "url": "https://github.com/alexandrainst/alexandra-trackmap-panel"
+        },
+        {
+          "version": "2.1.0",
+          "commit": "9859a67865e55b145c2da2aab581e043c6387aed",
+          "url": "https://github.com/alexandrainst/alexandra-trackmap-panel"
         }
       ]
     },


### PR DESCRIPTION
Major rewrite, supporting Grafana 7, but dropping Grafana 6.

https://github.com/alexandrainst/alexandra-trackmap-panel/releases/tag/2.1.0
https://github.com/alexandrainst/alexandra-trackmap-panel/pull/24