### PR TITLE
OpenNMS Helm 5.0.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -695,6 +695,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "5.0.2",
+          "commit": "5fc338fc0ef505b152518ec9cd39d552653908d5",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "5.0.1",
           "commit": "b1c7e0e78901ce46a32c8f5f4c28b36d8106e30d",
           "url": "https://github.com/OpenNMS/opennms-helm"

--- a/repo.json
+++ b/repo.json
@@ -695,6 +695,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "5.0.3",
+          "commit": "adf709157c0d1db9ba2c46622d6688f76f9d7d93",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "5.0.2",
           "commit": "5fc338fc0ef505b152518ec9cd39d552653908d5",
           "url": "https://github.com/OpenNMS/opennms-helm"


### PR DESCRIPTION
This is a re-pull of [this PR](https://github.com/grafana/grafana-plugin-repository/pull/609) because I think it got lost in the shuffle when it fell to page 2.  I also have an update for our plugin version 6.0.0, but I will do that as a separate PR since otherwise the validator fails on updating 2 plugins in one PR.  I'd still like to see 5.0.3 merged even though we have a newer version, since it's the last version to support older Grafana 6.x releases.  Thanks!

Here's the original comment for 5.0.3:

---

This release does not yet fix Grafana 7 support (it's complicated...) but it fixes a few more bugs while
we work on Grafana 7 support.

Also note, the docs that used to be included in the archive are now published at https://docs.opennms.com/ -- our
future home for all OpenNMS documentation.

* Make Helm docs publicly available (Issue [HELM-221](http://issues.opennms.org/browse/HELM-221))
* "How to configure the data sources in Grafana" docs are missing (Issue [HELM-231](http://issues.opennms.org/browse/HELM-231))
* Enhance HELM documentation (Issue [HELM-240](http://issues.opennms.org/browse/HELM-240))
* Add expression examples (Issue [HELM-241](http://issues.opennms.org/browse/HELM-241))
* JEXL expressions (Issue [HELM-242](http://issues.opennms.org/browse/HELM-242))
* Cannot see list of nodes and resources when editing a panel. (Issue [HELM-243](http://issues.opennms.org/browse/HELM-243))
* update requirements (Issue [HELM-251](http://issues.opennms.org/browse/HELM-251))