### PR TITLE
OpenNMS Helm 6.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -778,6 +778,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "5.0.3",
+          "commit": "adf709157c0d1db9ba2c46622d6688f76f9d7d93",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "5.0.2",
           "commit": "5fc338fc0ef505b152518ec9cd39d552653908d5",
           "url": "https://github.com/OpenNMS/opennms-helm"

--- a/repo.json
+++ b/repo.json
@@ -778,6 +778,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "5.0.2",
+          "commit": "5fc338fc0ef505b152518ec9cd39d552653908d5",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "5.0.1",
           "commit": "b1c7e0e78901ce46a32c8f5f4c28b36d8106e30d",
           "url": "https://github.com/OpenNMS/opennms-helm"

--- a/repo.json
+++ b/repo.json
@@ -778,6 +778,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "6.0.0",
+          "commit": "c93251b9ed0c344452be281b9a95c1fb1bf78ec6",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "5.0.3",
           "commit": "adf709157c0d1db9ba2c46622d6688f76f9d7d93",
           "url": "https://github.com/OpenNMS/opennms-helm"


### PR DESCRIPTION
As noted in #768, we have updates to both Helm 5 and now Helm 6. This is the Helm 6 update, which adds Grafana 7 support:

---

OpenNMS Helm now supports Grafana 7, and has dropped support for versions older than 7.

* the `nodeResources()` function has been enhanced to support displaying the resource label (Issue [HELM-95](https://issues.opennms.org/browse/HELM-95))
* the Filter and Alarm Table panels have been updated to work with Grafana 7 (Issue [HELM-247](https://issues.opennms.org/browse/HELM-247))