### PR TITLE
fix: update linter for new url-based publishing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "lint-repo",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/scripts/lint-repo.js",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "lint-repo-update",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/scripts/lint-repo-update.js",
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/repo.json
+++ b/repo.json
@@ -1447,6 +1447,17 @@
       "url": "https://github.com/briangann/grafana-gauge-panel",
       "versions": [
         {
+          "version": "0.0.8",
+          "commit": "c7dd8e27e2a93edee3e2373adffdb95ef46e30d4",
+          "url": "https://github.com/briangann/grafana-gauge-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/briangann/grafana-gauge-panel/releases/download/v0.0.8/briangann-gauge-panel-0.0.8.zip",
+              "md5": "9cc61347c03454aaf3cdad68f7757a4a"
+            }
+          }
+        },
+        {
           "version": "0.0.6",
           "commit": "a4531b408d05cb1607c81de310753b62d6e510c0",
           "url": "https://github.com/briangann/grafana-gauge-panel"

--- a/repo.json
+++ b/repo.json
@@ -1448,12 +1448,11 @@
       "versions": [
         {
           "version": "0.0.8",
-          "commit": "c7dd8e27e2a93edee3e2373adffdb95ef46e30d4",
           "url": "https://github.com/briangann/grafana-gauge-panel",
           "download": {
             "any": {
               "url": "https://github.com/briangann/grafana-gauge-panel/releases/download/v0.0.8/briangann-gauge-panel-0.0.8.zip",
-              "md5": "9cc61347c03454aaf3cdad68f7757a4a"
+              "md5": "782c973460f330287b7efca5486aa015"
             }
           }
         },

--- a/scripts/github/github.js
+++ b/scripts/github/github.js
@@ -1,3 +1,5 @@
+/*jshint esversion: 8 */
+
 const request = require('request-promise-native');
 const { GITHUB_API_TOKEN } = process.env;
 
@@ -27,7 +29,7 @@ async function fetchContent(url) {
 }
 
 async function fetchPRFile(owner, repo, pr, filename) {
-  const endpont = `/repos/${owner}/${repo}/pulls/${pr}/files`
+  const endpont = `/repos/${owner}/${repo}/pulls/${pr}/files`;
   const prFiles = await apiRequest(endpont);
   for (const prFile of prFiles) {
     if (prFile.filename === filename) {

--- a/scripts/lint-plugin.js
+++ b/scripts/lint-plugin.js
@@ -14,7 +14,7 @@ if (process.argv.length > 5) {
 
 console.log(`${pluginUrl} : ${commit}`);
 
-return lintPlugin(pluginUrl, commit, version, pluginId).then(result => {
+return lintPlugin(pluginUrl, commit, version, download, pluginId).then(result => {
   // console.debug(result);
   if (result && result.statusCode > 0) {
     console.error(chalk.yellow(result.status));

--- a/scripts/lint-repo.js
+++ b/scripts/lint-repo.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+/*jshint esversion: 8 */
+
 const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
@@ -13,7 +15,7 @@ async function main(options) {
   try {
     pluginsRepo = getRepo();
   } catch(err) {
-    console.error(chalk.red('Error processing repo.json'))
+    console.error(chalk.red('Error processing repo.json'));
     console.error(err);
     process.exit(1);
   }
@@ -51,11 +53,12 @@ async function main(options) {
 
     let commit = version.commit;
     let url = version.url;
+    let download = version.download || null;
 
     // console.log(`Linting plugin ${chalk.blue(plugin.id)}`);
     console.log(`Linting ${chalk.blue(plugin.id)} version ${chalk.blue(version.version)}`);
     try {
-      const lintResult = await lintPlugin(url, commit, version.version, plugin.id);
+      const lintResult = await lintPlugin(url, commit, version.version, download, plugin.id);
       if (lintResult) {
         if (lintResult && lintResult.statusCode > 0) {
           console.error(chalk.yellow(lintResult.status));

--- a/scripts/lintPlugin.js
+++ b/scripts/lintPlugin.js
@@ -1,17 +1,22 @@
+/*jshint esversion: 8 */
 const request = require('request-promise-native');
 const semver = require('semver');
 const { fetchPluginJson } = require('./github/github');
+const chalk = require('chalk');
 
 const PLUGIN_TYPES = ['datasource', 'panel', 'app', 'renderer'];
 const PLUGIN_ID_PATTERN = new RegExp(`^[a-z0-9]+(-[a-z0-9]+)*-(${PLUGIN_TYPES.join('|')})$`);
 
-async function lintPlugin(url, commit, version, pluginId) {
+async function lintPlugin(url, commit, version, download, pluginId) {
   const postData = {
     url: url,
     commit: commit
   };
+  if (download) {
+    postData.download = download;
+  }
 
-  const apiResponse = await request.post({url:'https://grafana.com/api/plugins/lint', form: postData});
+  const apiResponse = await request.post({ url: 'https://grafana.com/api/plugins/lint', form: postData });
   // console.debug(apiResponse);
   const linterResult = JSON.parse(apiResponse);
 
@@ -28,22 +33,22 @@ async function lintPlugin(url, commit, version, pluginId) {
       linterResult.lintErrors.forEach(err => {
         // Do not fail on "The README.md file contains HTML tags" error
         if (htmlTagsErrorPattern.test(err)) {
-          result.status = 'Warning'
+          result.status = 'Warning';
           result.statusCode = 1;
           result.warnings.push(err);
         } else {
-          result.status = 'Error'
+          result.status = 'Error';
           result.statusCode = 2;
           result.errors.push(err);
         }
       });
     } else {
-      result.status = 'Error'
+      result.status = 'Error';
       result.statusCode = 2;
     }
   }
 
-  if(pluginId) {
+  if (pluginId) {
     try {
       const publishedVersion = await getPublishedVersion(pluginId);
       if (semver.gt(publishedVersion, version)) {
@@ -59,52 +64,57 @@ async function lintPlugin(url, commit, version, pluginId) {
           addWarning(error, result);
         }
       }
-    } catch(err) {}
+    } catch (err) { }
   }
 
-  // Try to fetch plugin.json and make some additional checks
-  try {
-    const pluginJsonResponse = await fetchPluginJson(url, commit);
-    const pluginJson = pluginJsonResponse.json;
-    // console.log(pluginJson);
-    if (pluginJsonResponse.prefix === 'src') {
-      addWarning(`It seems, plugin isn't built properly: plugin.json found in src/ only`, result);
-    }
+  // if the linter from api is valid, and there is no commit returned, this is a zip-style plugin
+  if (linterResult.commit === '') {
+    console.log(`Plugin ${chalk.blue(pluginId)} version ${chalk.blue(version)} published with download url to zip, skipping dist check.`);
+  } else {
+    // Try to fetch plugin.json and make some additional checks
+    try {
+      const pluginJsonResponse = await fetchPluginJson(url, commit);
+      const pluginJson = pluginJsonResponse.json;
+      // console.log(pluginJson);
+      if (pluginJsonResponse.prefix === 'src') {
+        addWarning(`It seems, plugin isn't built properly: plugin.json found in src/ only`, result);
+      }
 
-    if (pluginId !== pluginJson.id) {
-      addWarning(`Plugin id in repo.json (${pluginId}) doesn't match plugin.json (${pluginJson.id})`, result);
-    }
+      if (pluginId !== pluginJson.id) {
+        addWarning(`Plugin id in repo.json (${pluginId}) doesn't match plugin.json (${pluginJson.id})`, result);
+      }
 
-    if (!pluginJson.id) {
-      addError('No plugin id found in plugin.json', result);
-    }
+      if (!pluginJson.id) {
+        addError('No plugin id found in plugin.json', result);
+      }
 
-    // Plugin id rules
-    const validSlug = PLUGIN_ID_PATTERN.test(pluginJson.id);
-    if (!validSlug) {
-      addError(`Invalid plugin id "${pluginJson.id}" found in plugin.json`, result);
-    }
+      // Plugin id rules
+      const validSlug = PLUGIN_ID_PATTERN.test(pluginJson.id);
+      if (!validSlug) {
+        addError(`Invalid plugin id "${pluginJson.id}" found in plugin.json`, result);
+      }
 
-    // TODO this check is duplicated in https://grafana.com/api/plugins/lint
-    // Plugin type rules
-    if (!PLUGIN_TYPES.includes(pluginJson.type)) {
-      addError(`Invalid plugin type - must be one of: datasource, panel or app, got "${pluginJson.type}"`, result);
-    }
+      // TODO this check is duplicated in https://grafana.com/api/plugins/lint
+      // Plugin type rules
+      if (!PLUGIN_TYPES.includes(pluginJson.type)) {
+        addError(`Invalid plugin type - must be one of: datasource, panel or app, got "${pluginJson.type}"`, result);
+      }
 
-    const pluginJsonVersion = pluginJson.info.version;
-    if (version && (!pluginJsonVersion || pluginJsonVersion !== version)) {
-      addWarning(`Version in repo.json (${version}) doesn't match plugin.json (${pluginJsonVersion})`, result);
-    }
+      const pluginJsonVersion = pluginJson.info.version;
+      if (version && (!pluginJsonVersion || pluginJsonVersion !== version)) {
+        addWarning(`Version in repo.json (${version}) doesn't match plugin.json (${pluginJsonVersion})`, result);
+      }
 
-    if (!(pluginJson.info.author && pluginJson.info.author.name)) {
-      addWarning(`No author specified in plugin.json`, result);
-    }
+      if (!(pluginJson.info.author && pluginJson.info.author.name)) {
+        addWarning(`No author specified in plugin.json`, result);
+      }
 
-    if (!pluginJson.info.description) {
-      addWarning(`No plugin description provided in plugin.json`, result);
+      if (!pluginJson.info.description) {
+        addWarning(`No plugin description provided in plugin.json`, result);
+      }
+    } catch (err) {
+      console.log(`Warning: failed fetching plugin.json. This may be caused by private repo without proper access rights.`);
     }
-  } catch(err) {
-    console.log(`Warning: failed fetching plugin.json. This may be caused by private repo without proper access rights.`);
   }
 
   if (result.statusCode < 2) {
@@ -119,7 +129,7 @@ async function getPublishedVersion(pluginId) {
     let plugin = await request.get(`https://grafana.com/api/plugins/${pluginId}`);
     plugin = JSON.parse(plugin);
     return plugin.version;
-  } catch(err) {
+  } catch (err) {
     // console.log(err.error || err.message || err);
     throw new Error(`Warning: unable to fetch published plugin ${pluginId}`);
   }
@@ -130,12 +140,12 @@ async function getOrg(orgSlug) {
     let result = await request.get(`https://grafana.com/api/orgs/${orgSlug}`);
     result = JSON.parse(result);
     return result;
-  } catch(err) {
+  } catch (err) {
     // console.log(err.error || err.message || err);
     let error = {};
     try {
       error = JSON.parse(err.error);
-    } catch(jsonErr) {}
+    } catch (jsonErr) { }
 
     throw new Error(`Unable to get organization ${orgSlug}, ${error.message || ''}`);
   }
@@ -152,7 +162,7 @@ function getOrgSlug(pluginId) {
 function addWarning(warning, result) {
   result.warnings.push(warning);
   if (result.statusCode < 1) {
-    result.status = 'Warning'
+    result.status = 'Warning';
     result.statusCode = 1;
   }
 }
@@ -160,7 +170,7 @@ function addWarning(warning, result) {
 function addError(error, result) {
   result.errors.push(error);
   if (result.statusCode < 2) {
-    result.status = 'Error'
+    result.status = 'Error';
     result.statusCode = 2;
   }
 }

--- a/scripts/lintRepoUpdate.js
+++ b/scripts/lintRepoUpdate.js
@@ -1,3 +1,5 @@
+/*jshint esversion: 8 */
+
 const _ = require('lodash');
 const chalk = require('chalk');
 const request = require('request-promise-native');

--- a/scripts/lintRepoUpdate.js
+++ b/scripts/lintRepoUpdate.js
@@ -32,12 +32,21 @@ function lintRepoDiff(diff) {
   _.forEach(diff.diff, (pluginUpdate, pluginId) => {
     _.forEach(pluginUpdate.versions, async versionObj => {
         const url = versionObj.url.trim();
-        const commit = versionObj.commit.trim();
+        let commit = versionObj.commit || null;
+        // commit is not required for zip releases
+        if (commit) {
+          commit = versionObj.commit.trim();
+        }
         const version = versionObj.version;
+        let download = versionObj.download || null;
 
         const lintPromise = lintPlugin(url, commit, version, download, pluginId).then(result => {
           console.log(`Linting ${chalk.blue(pluginId)} version ${chalk.blue(versionObj.version)}`);
-          console.log(`${url} ${commit}`);
+          if (commit) {
+            console.log(`${url} ${commit}`);
+          } else {
+            console.log(`${url} (uses download url)`);
+          }
           if (result && result.statusCode > 0) {
             console.error(chalk.yellow(result.status));
             result.warnings.forEach(err => console.error(chalk.yellow(err)));

--- a/scripts/lintRepoUpdate.js
+++ b/scripts/lintRepoUpdate.js
@@ -35,7 +35,7 @@ function lintRepoDiff(diff) {
         const commit = versionObj.commit.trim();
         const version = versionObj.version;
 
-        const lintPromise = lintPlugin(url, commit, version, pluginId).then(result => {
+        const lintPromise = lintPlugin(url, commit, version, download, pluginId).then(result => {
           console.log(`Linting ${chalk.blue(pluginId)} version ${chalk.blue(versionObj.version)}`);
           console.log(`${url} ${commit}`);
           if (result && result.statusCode > 0) {


### PR DESCRIPTION
Signed plugins will have only zip files and are validated via the api.

This checks that the api returns valid, and skips the "dist" and "src" tests since the files are not in branch.

Also fixed a bunch of js-hint errors.

this updates the gauge-panel to test out the new code also.
