### PR TITLE
Update fifemon-graphql-datasource to v1.2.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -5004,6 +5004,11 @@
           "version": "1.1.3",
           "commit": "d0c0fbd29b75caa761ce0b55032e4196e55532c1",
           "url": "https://github.com/fifemon/graphql-datasource"
+        },
+        {
+          "version": "1.1.4",
+          "commit": "15bc0b6c59853b578f46a4dc7b58017dc884069d",
+          "url": "https://github.com/fifemon/graphql-datasource"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -5006,9 +5006,15 @@
           "url": "https://github.com/fifemon/graphql-datasource"
         },
         {
-          "version": "1.1.4",
-          "commit": "15bc0b6c59853b578f46a4dc7b58017dc884069d",
-          "url": "https://github.com/fifemon/graphql-datasource"
+          "version": "1.2.0",
+          "commit": "d7653f69b9e5a410bcc1ea185c845343dac837a7",
+          "url": "https://github.com/fifemon/graphql-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/fifemon/graphql-datasource/releases/download/v1.2.0/fifemon-graphql-datasource-1.2.0.zip",
+              "md5": "fa82a90a78a225512c33561a178c34c0"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
Minor changes from v1.1.3, but an important bug fix:

* **improvement** Use templateSrv to interpolate timeFrom and timeTo variables.
* **bug fix** Fix error in isRFC3339_ISO6801 when field is non-string 