### PR TITLE
Instana datasource plugin 3.1.2

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3026,6 +3026,17 @@
           "version": "3.1.1",
           "commit": "7ae977992e2c63b540f2ab02be336a2202dc5a61",
           "url": "https://github.com/instana/instana-grafana-datasource"
+        },
+        {
+          "version": "3.1.2",
+          "commit": "14e6e83a1d3e9ddbd182cc1fff7b60744ed2abcc",
+          "url": "https://github.com/instana/instana-grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/instana/instana-grafana-datasource/releases/download/v3.1.2/instana-datasource-3.1.2.zip",
+              "md5": "e3b9224414ab86e4f36bf68d7dad2b91"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
* sign the plugin
* fix `422` errors ("timeFrame.windowSize must be greater than or equal to 0") while using timeshift