### PR TITLE
Add Humio-datasource plugin 

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4859,6 +4859,23 @@
           }
         }
       ]
+    },
+    {
+      "id": "humio-datasource",
+      "type": "datasource",
+      "url": "https://github.com/humio/humio2grafana",
+      "versions": [
+        {
+          "version": "3.1.1",
+          "url": "https://github.com/humio/humio2grafana",
+          "download": {
+            "any": {
+              "url": "https://github.com/humio/humio2grafana/releases/download/v3.1.1/humio.zip",
+              "md5": "593c48f67a2f2d1334b54d013d39cd2b"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Initial version of Humio datasource plugin.

Instructions for test:
1. Create a free account on https://cloud.humio.com/
2. Under profile go to `your account`
3. Copy API token
4. Create Humio Datasource in Grafana by using https://cloud.humio.com/ as the url and by pasting the API token you just copied.

This should create a datasource with 3 repos, where humio-metrics and humio-audit have data. 
General instructions for use can be found in the docs: https://docs.humio.com/integrations/send-humio-data/grafana/
You'll need to use some Humio queries to fetch some data for the panels. The docs for the query language can be found here: https://docs.humio.com/query-functions/
