### PR TITLE
Update fetzerch-sunandmoon-datasource plugin (v0.2.0)

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -996,6 +996,16 @@
       "url": "https://github.com/fetzerch/grafana-sunandmoon-datasource",
       "versions": [
         {
+          "version": "0.2.0",
+          "url": "https://github.com/fetzerch/grafana-sunandmoon-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/fetzerch/grafana-sunandmoon-datasource/releases/download/v0.2.0/fetzerch-sunandmoon-datasource-0.2.0.zip",
+              "md5": "97340c107bfdb9829d6eeb479b87828f"
+            }
+          }
+        },
+        {
           "version": "0.1.6",
           "commit": "1ae8870d0c539bc7eb787f4b61813eae103ec87a",
           "url": "https://github.com/fetzerch/grafana-sunandmoon-datasource"


### PR DESCRIPTION
Fixed

* Glitches in graphs caused by out of order data. (#29, grafana/#28804)
* Annotations are no longer shown. (#31)
* A metric is now preselected when using the datasource on a new panel.

Added

* Location is now automatically configured.

Changed

* The plugin was migrated to the new plugin framework introduced in
  Grafana 7.0 and is no longer compatible with older versions of
  Grafana.

---
See the "dev-env" directory for how to setup a minimal docker environment for testing.