### PR TITLE
Cognite datasource patch v2.1.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3585,6 +3585,17 @@
               "md5": "c661fa8d603deed7576c348d4bc8ef88"
             }
           }
+        },
+        {
+          "version": "2.1.1",
+          "commit": "0e5e4add82b6406cdb4c96caed9ed4718bfe2dc9",
+          "url": "https://github.com/cognitedata/cognite-grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/cognitedata/cognite-grafana-datasource/releases/download/v2.1.1/cognitedata-datasource-2.1.1.zip",
+              "md5": "049c6e5ad00140423c2b8a0f96642503"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
We encountered some issues with the latest release https://github.com/grafana/grafana-plugin-repository/pull/791

In version 2.1.0 `$variable` used as an `Asset tag` worked for earlier created dashboards, but it was impossible to create a new panel with the same capability. It was also not possible to see which variable is used as empty input field was shown instead.

Before the fix:
<img width="836" alt="Screenshot 2020-11-23 at 10 06 46" src="https://user-images.githubusercontent.com/10908415/99945478-faac8a80-2d74-11eb-9105-cc986192cbc0.png">

After:
<img width="873" alt="Screenshot 2020-11-23 at 10 06 30" src="https://user-images.githubusercontent.com/10908415/99945494-013b0200-2d75-11eb-8ea3-8b22c4d36ded.png">
