### PR TITLE
Adding thalysantana-appcenter-datasource v1.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4748,12 +4748,12 @@
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "875041934274c51effee10f0ad8609e32f8dd0d4",
+          "commit": "8cb0a9a0039267d571c329479fc911f02fe25d16",
           "url": "https://github.com/thalysantana/grafana-appcenter-datasource",
           "download": {
             "any": {
               "url": "https://github.com/thalysantana/grafana-appcenter-datasource/releases/download/v1.0.0/thalysantana-appcenter-datasource-1.0.0.zip",
-              "md5": "6d9ca2a81221cb1c770a6949cc3d61fd"
+              "md5": "7505a95c3a54dc82f887d5f2466648d3"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -4748,12 +4748,12 @@
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "8cb0a9a0039267d571c329479fc911f02fe25d16",
+          "commit": "3a1dcabd983467be6926ca6fa6e726a0a86d8e7d",
           "url": "https://github.com/thalysantana/grafana-appcenter-datasource",
           "download": {
             "any": {
               "url": "https://github.com/thalysantana/grafana-appcenter-datasource/releases/download/v1.0.0/thalysantana-appcenter-datasource-1.0.0.zip",
-              "md5": "7505a95c3a54dc82f887d5f2466648d3"
+              "md5": "c1064d6b2463bbff2588c2d9d51a32ba"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -4740,6 +4740,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "thalysantana-appcenter-datasource",
+      "type": "app",
+      "url": "https://github.com/thalysantana/grafana-appcenter-datasource",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "875041934274c51effee10f0ad8609e32f8dd0d4",
+          "url": "https://github.com/thalysantana/grafana-appcenter-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/thalysantana/grafana-appcenter-datasource/releases/download/v1.0.0/thalysantana-appcenter-datasource-1.0.0.zip",
+              "md5": "6d9ca2a81221cb1c770a6949cc3d61fd"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
A User API Token is required to connect to the App Center. 
Install instructions provided on README.md. 
Plugin signed and packaged as required by Grafana's team.