### PR TITLE
ClickHouse Database datasource plugin update to 2.2.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2093,6 +2093,11 @@
           "version": "2.1.0",
           "commit": "bcee398e90e5f3ddb1140034c9f436b1b399a158",
           "url": "https://github.com/Vertamedia/clickhouse-grafana"
+        },
+        {
+          "version": "2.2.0",
+          "commit": "67e5b7f80cfe5198db9ac8fdabfe2d70c7f2aaa1",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2096,9 +2096,13 @@
         },
         {
           "version": "2.2.0",
-          "commit": "67e5b7f80cfe5198db9ac8fdabfe2d70c7f2aaa1",
-          "url": "https://github.com/Vertamedia/clickhouse-grafana"
-        }
+          "url": "https://github.com/Vertamedia/clickhouse-grafana",
+          "download": {
+            "any": {
+              "url": "https://github.com/Vertamedia/clickhouse-grafana/archive/2.2.0.zip",
+              "md5": "b4a3089dddf134f9e9204c9ce79a9cae"
+            }
+          }        }
       ]
     },
     {

--- a/repo.json
+++ b/repo.json
@@ -2097,6 +2097,7 @@
         {
           "version": "2.2.0",
           "url": "https://github.com/Vertamedia/clickhouse-grafana",
+          "commit": "67e5b7f80cfe5198db9ac8fdabfe2d70c7f2aaa1",
           "download": {
             "any": {
               "url": "https://github.com/Vertamedia/clickhouse-grafana/releases/download/2.2.0/vertamedia-clickhouse-datasource-2.2.0.zip",

--- a/repo.json
+++ b/repo.json
@@ -2101,7 +2101,7 @@
           "download": {
             "any": {
               "url": "https://github.com/Vertamedia/clickhouse-grafana/releases/download/2.2.0/vertamedia-clickhouse-datasource-2.2.0.zip",
-              "md5": "85a73875352667ca1276f107a4c6d246"
+              "md5": "f2277537425f199aa1682da51ec02fa4"
             }
           }        }
       ]

--- a/repo.json
+++ b/repo.json
@@ -2144,9 +2144,10 @@
           "download": {
             "any": {
               "url": "https://github.com/Vertamedia/clickhouse-grafana/releases/download/2.2.0/vertamedia-clickhouse-datasource-2.2.0.zip",
-              "md5": "f2277537425f199aa1682da51ec02fa4"
+              "md5": "db39ab7708c1ef2a08ad0ad98598c3ce"
             }
-          }        }
+          }
+        }
       ]
     },
     {

--- a/repo.json
+++ b/repo.json
@@ -2099,8 +2099,8 @@
           "url": "https://github.com/Vertamedia/clickhouse-grafana",
           "download": {
             "any": {
-              "url": "https://github.com/Vertamedia/clickhouse-grafana/archive/2.2.0.zip",
-              "md5": "b4a3089dddf134f9e9204c9ce79a9cae"
+              "url": "https://github.com/Vertamedia/clickhouse-grafana/releases/download/2.2.0/vertamedia-clickhouse-datasource-2.2.0.zip",
+              "md5": "85a73875352667ca1276f107a4c6d246"
             }
           }        }
       ]


### PR DESCRIPTION
# 2.2.0 (2020-11-30)
## Enhancement:

* add region support to annotation query, try to fix wrong column orders for table format, fix https://github.com/Vertamedia/clickhouse-grafana/issues/303
* add plugin sign process, fix https://github.com/Vertamedia/clickhouse-grafana/issues/212
* add `DateTime64` support, fix https://github.com/Vertamedia/clickhouse-grafana/issues/292
* add `linux\arm64` backend plugin build
* improve ARRAY JOIN parsing, fix https://github.com/Vertamedia/clickhouse-grafana/issues/284
* improve `docker-compose.yaml` add ability to redefine `GRAFANA_VERSION` and `CLICKHOUSE_VERSION` via environment variables `latest` by default

## Fixes:
* add `*.js.map` and `*.js` from src and spec folder to .gitignore
* don't apply adhoc filters twice when used $adhoc macros, fix https://github.com/Vertamedia/clickhouse-grafana/issues/282
* fix corner case for table format with wrong columns order between meta and data response section, fix https://github.com/Vertamedia/clickhouse-grafana/issues/281
* add trickster to docker-compose environment
* actualize links in README.md

Signed-off-by: Eugene Klimov <eklimov@altinity.com>