### PR TITLE
TDengine datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4825,7 +4825,7 @@
       "versions": [
           {
             "version": "2.0.0",
-            "commit": "3dfed23bf803484ef1faa21af155d4aed81d5e12",
+            "commit": "d598db167eb256fe67409b7bb3d0eb7fffc3ff8c",
             "url": "https://github.com/taosdata/grafanaplugin"
           }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4820,6 +4820,17 @@
       ]
     },
     {
+      "id": "taosdata-tdengine-datasource",
+      "type": "datasource",
+      "versions": [
+          {
+            "version": "2.0.0",
+            "commit": "3dfed23bf803484ef1faa21af155d4aed81d5e12",
+            "url": "https://github.com/taosdata/grafanaplugin"
+          }
+      ]
+    },
+    {
       "id": "factrylabs-untimely-panel",
       "type": "panel",
       "url": "https://github.com/factrylabs/untimely-grafana-panel",

--- a/repo.json
+++ b/repo.json
@@ -4822,11 +4822,15 @@
     {
       "id": "taosdata-tdengine-datasource",
       "type": "datasource",
+      "url": "https://github.com/taosdata/grafanaplugin",
       "versions": [
           {
             "version": "2.0.0",
-            "commit": "d598db167eb256fe67409b7bb3d0eb7fffc3ff8c",
-            "url": "https://github.com/taosdata/grafanaplugin"
+            "url": "https://github.com/taosdata/grafanaplugin",
+            "download": {
+              "url": "https://github.com/taosdata/grafanaplugin/releases/download/v2.0.0/tdengine-grafana-plugin-v2.0.0.tar.gz",
+              "md5": "67e9d6d0ad2430ef5f427a454bb2cf33"
+            }
           }
       ]
     },


### PR DESCRIPTION
TDengine is an open-source big data platform designed and optimized for Internet of Things (IoT), Connected Vehicles, and Industrial IoT. Besides the 10x faster time-series database, it provides caching, stream computing, message queuing and other functionalities to reduce the complexity and costs of development and operations.

For verifying the TDengine data source plugin, please refer to https://www.taosdata.com/en/documentation/connections-with-other-tools/#Grafana. But need change TDengine RESTful port from 6020 to 6041.

TDengine docker can be run as following command:

docker run tdengine/tdengine:latest
Thanks.