### PR TITLE
Update KubeGraf version to v1.5.0 

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4077,7 +4077,7 @@
           "version": "1.4.2",
           "commit": "dd00d1b7570c2f012e6fde1c734f51e5cf6f16c0",
           "url": "https://github.com/devopsprodigy/kubegraf"
-        ,
+        },
         {
           "version": "1.5.0",
           "commit": "1cbb507c4d12a9bea5a6f35bfad320a14af9ffd3",

--- a/repo.json
+++ b/repo.json
@@ -4084,8 +4084,8 @@
           "url": "https://github.com/devopsprodigy/kubegraf",
           "download" : {
             "any" : {
-              "url": "https://github.com/devopsprodigy/kubegraf/releases/download/v1.5.0.2/devopsprodigy-kubegraf-app-1.5.0.zip",
-              "md5": "3b43e6b6a0b3f28697c3a2a74b161881"
+              "url": "https://github.com/devopsprodigy/kubegraf/releases/download/v1.5.0.3/devopsprodigy-kubegraf-app-1.5.0.zip",
+              "md5": "30e532eedaf024921bcdf8b39c2c7066"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -4084,8 +4084,8 @@
           "url": "https://github.com/devopsprodigy/kubegraf",
           "download" : {
             "any" : {
-              "url": "https://github.com/devopsprodigy/kubegraf/releases/download/v1.5.0.3/devopsprodigy-kubegraf-app-1.5.0.zip",
-              "md5": "30e532eedaf024921bcdf8b39c2c7066"
+              "url": "https://github.com/devopsprodigy/kubegraf/releases/download/v1.5.0.4/devopsprodigy-kubegraf-app-1.5.0.zip",
+              "md5": "4d35dc47b16af1a152b8dd29d24ff637"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -4081,7 +4081,13 @@
         {
           "version": "1.5.0",
           "commit": "ee5827537b152e5d783e915b46c137f961e83929",
-          "url": "https://github.com/devopsprodigy/kubegraf"
+          "url": "https://github.com/devopsprodigy/kubegraf",
+          "download" : {
+            "any" : {
+              "url": "https://github.com/devopsprodigy/kubegraf/releases/download/v1.5.0.2/devopsprodigy-kubegraf-app-1.5.0.zip",
+              "md5": "3b43e6b6a0b3f28697c3a2a74b161881"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4080,7 +4080,7 @@
         },
         {
           "version": "1.5.0",
-          "commit": "1cbb507c4d12a9bea5a6f35bfad320a14af9ffd3",
+          "commit": "ee5827537b152e5d783e915b46c137f961e83929",
           "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -4077,6 +4077,11 @@
           "version": "1.4.2",
           "commit": "dd00d1b7570c2f012e6fde1c734f51e5cf6f16c0",
           "url": "https://github.com/devopsprodigy/kubegraf"
+        ,
+        {
+          "version": "1.5.0",
+          "commit": "1cbb507c4d12a9bea5a6f35bfad320a14af9ffd3",
+          "url": "https://github.com/devopsprodigy/kubegraf"
         }
       ]
     },


### PR DESCRIPTION
### New Features 
* Indicate when limits or requests are not setup for application
* Add cpu/memory limits of containers to Nodes' overview page
* Indicate cpu/memory usage of pod depending on the requests & limits on Nodes' overview page
* Add cpu/memory limits of containers to deployments/statefulsets/daemonsets/pods dashboards
* Hide empty namespaces on deployments/statefulsets/daemonsets dashboards
* Add NAMESPACE for k8s-manifests [#44](https://github.com/devopsprodigy/kubegraf/issues/44)  
* Sort alerts via priority  
* Little navigations improvements
* Add hide-button for alerts' table

### Bug Fixes
* Compatibility with Grafana >= 7.3.* [#48](https://github.com/devopsprodigy/kubegraf/issues/48)
* Show memory/cpu usage of pod on pod's dashboard [#41](https://github.com/devopsprodigy/kubegraf/pull/41)
* Fix white theme on new versions of Grafana
* Fix legends on all dashboards 