### PR TITLE
gapit-htmlgraphics-panel update v1.2.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4968,6 +4968,16 @@
               "md5": "46c36f55bd8e6bc2bbe8c230506c5dc2"
             }
           }
+        },
+        {
+          "version": "1.2.0",
+          "url": "https://github.com/gapitio/gapit-htmlgraphics-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/gapitio/gapit-htmlgraphics-panel/releases/download/v1.2.0/gapit-htmlgraphics-panel-1.2.0.zip",
+              "md5": "546f08335ccf4f73e38b1d669dc0687e"
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
Hello again :D

New update for gapit-htmlgraphics-panel.

## v1.2.0 (2020-12-18)

### Features / enhancements

- **Options**: Add overflow radio option [#8](https://github.com/gapitio/gapit-htmlgraphics-panel/pull/8)
- **Options**: Add import and export of panel options [#9](https://github.com/gapitio/gapit-htmlgraphics-panel/pull/9)


Which basically adds an [overflow option](https://github.com/gapitio/gapit-htmlgraphics-panel/blob/master/README.md#overflow) and a way to easily [export/import](https://github.com/gapitio/gapit-htmlgraphics-panel/blob/master/README.md#importexport) without ruining queries.