### PR TITLE
Zabbix plugin version 4.1.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -173,6 +173,17 @@
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
         {
+          "version": "4.1.0",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix",
+          "commit": "cdc891e3c6ffdbc59982971ecd83e7258608247d",
+          "download": {
+            "any": {
+              "url": "https://github.com/alexanderzobnin/grafana-zabbix/releases/download/v4.1.0/alexanderzobnin-zabbix-app-4.1.0.zip",
+              "md5": "af7a4bf019c052d5ecd00e74672eaae9"
+            }
+          }
+        },
+        {
           "version": "4.0.2",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix",
           "commit": "6b1067a05a4d1c89ce09945dac164e71b9eac991",


### PR DESCRIPTION
Zabbix plugin 4.1.0

## [4.1.0] - 2020-12-28
### Added
- [Data Frames](https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/) support, [#10820](https://github.com/alexanderzobnin/grafana-zabbix/issues/10820). This solves various issues below:
- Use units configured in Zabbix if possible
- Use value mappings from Zabbix
- Align points in each series to prevent stacking graph issues
- Fill missing points with null values, [#1109](https://github.com/alexanderzobnin/grafana-zabbix/issues/1109)
- Problems: filter problems by time range, [#1094](https://github.com/alexanderzobnin/grafana-zabbix/issues/1094)
- ARM build (ARM64 and ARM v6), [#1028](https://github.com/alexanderzobnin/grafana-zabbix/issues/1028)

### Fixed
- Grafana doesn't prevent from saving alerts with template variables, [#1100](https://github.com/alexanderzobnin/grafana-zabbix/issues/1100)
- Query inspector is not working, [#1097](https://github.com/alexanderzobnin/grafana-zabbix/issues/1097)
- Problems panel query editor issues, [#988](https://github.com/alexanderzobnin/grafana-zabbix/issues/988)
- Problems: unable to change severity to Not Classified, [#1104](https://github.com/alexanderzobnin/grafana-zabbix/issues/1104)
- Problems: ack message limited to 64 characters, [#1122](https://github.com/alexanderzobnin/grafana-zabbix/issues/1122)