### PR TITLE
Update Redis Data Source 1.3.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4838,6 +4838,17 @@
               "md5": "f40a9ccd55d10ff315faff915c6b277d"
             }
           }
+        },
+        {
+          "version": "1.3.0",
+          "commit": "2edc20bc1c578c892734c89464cf9ffec94e5fd6",
+          "url": "https://github.com/RedisGrafana/grafana-redis-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-datasource/releases/download/1.3.0/redis-datasource-1.3.0.zip",
+              "md5": "a2ec06c3a98fcb51b02bb961c876045a"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4845,7 +4845,7 @@
           "url": "https://github.com/RedisGrafana/grafana-redis-datasource",
           "download": {
             "any": {
-              "url": "https://github.com/RedisGrafana/grafana-redis-datasource/releases/download/1.3.0/redis-datasource-1.3.0.zip",
+              "url": "https://github.com/RedisGrafana/grafana-redis-datasource/releases/download/v1.3.0/redis-datasource-1.3.0.zip",
               "md5": "a2ec06c3a98fcb51b02bb961c876045a"
             }
           }


### PR DESCRIPTION
@marcusolsson Please review and add a new version of Redis Data Source 1.3.0.

To start docker-compose with test database please do: `npm run start:dev`

### Breaking changes

- HGETALL returns hash fields in a row similar to HGET, HMGET to support streaming. Previously each hash field returned as a row.
- Time Bucket for RedisTimeSeries TS.RANGE and TS.MRANGE was updated from string to integer. To fix the dashboard JSON:
  - Search for `"bucket"="X"`
  - Remove quotes
- RedisTimeSeries TS.RANGE command was updated to have legend and value override similar to TS.MRANGE. Previous `legend` defined field's name.
- `key` parameter for commands like GET, HGET, SMEMBERS was updated to `keyName` to avoid conflicts. To fix the dashboard JSON:
  - Search for `"key"="X"`
  - Replace to `"keyName"="X"`

### Features / Enhancements

- Update description and GitHub issues #83
- Add RediSearch FT.INFO command #97
- Add HMGET Command #98
- Update release workflow #99
- Update Grafana dependencies to 7.3.5 #100
- Update Grafana SDK 0.80.0 #101
- Update data source icon and refactoring #102
- Update field's name for HGET command to align with HMGET #103
- Update HGETALL command to return fields and support streaming similar to HGET, HMGET #104
- Add tests for React Config and Query editors #105
- Remove CircleCI and move to Github Actions #106
- Update Bucket's type (string->number) and add type values for Aggregation and Info sections #108
- Add tests for React Data Source #113
- Update Bucket to Time Bucket in Query Editor #114
- Check if a string value is a number when streaming #115
- Add Tests Coverage #117
- Add Empty Array when no values returned similar to redis-cli #120, #121
- Add test data for backend testing #122

### Bug fixes

- Fix "NOAUTH Authentication required" error with sentinel #109
- Add Value Label to TS.RANGE command similar to TS.MRANGE #110
- Update default configuration parameters for Data Source #111
- Update Key to KeyName to avoid conflict in the Explore tab #112

![Screen Shot 2021-01-05 at 8 58 14 PM](https://user-images.githubusercontent.com/47795110/103732034-651f3000-4f9b-11eb-8988-4fce172713f0.png)


