### PR TITLE
Update frser-sqlite-datasource with v0.2.7

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2706,6 +2706,16 @@
               "md5": "024d6de519e0fab7d0d16a2a29f4dec3"
             }
           }
+        },
+        {
+          "version": "0.2.7",
+          "url": "https://github.com/fr-ser/grafana-sqlite-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/fr-ser/grafana-sqlite-datasource/releases/download/v0.2.7/frser-sqlite-datasource-0.2.7.zip",
+              "md5": "642de2cd91b2bf2ac24e2b1b4e055950"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
This is an update to the existing plugin (initial PR was this: https://github.com/grafana/grafana-plugin-repository/pull/755).

A summary of changes can be found here: https://github.com/fr-ser/grafana-sqlite-datasource/blob/master/CHANGELOG.md