### PR TITLE
Add v0.2.0 of the Untimely Factry panel

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4931,6 +4931,16 @@
           "version": "0.1.1",
           "commit": "78fb7a9c1622a632721a14838dc5005f8aabcd90",
           "url": "https://github.com/factrylabs/untimely-grafana-panel"
+        },
+        {
+          "version": "0.2.0",
+          "url": "https://github.com/factrylabs/untimely-grafana-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/factrylabs/untimely-grafana-panel/releases/download/v0.2.0/factry-untimely-panel-0.2.0.zip",
+              "md5": "f38e46f1a29ab861da1af8aead35511f"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
Update Untimely panel to v.0.2.0

This fixes the editor that was not showing for versions of Grafana > 7.3