### PR TITLE
Version 2.0.0 of aquaqanalytics-kdbadaptor-datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4317,6 +4317,11 @@
           "version": "1.0.1",
           "commit": "291228ad93c6d8ff4763bc4f2027fe533755cc9c",
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
+        },
+		{
+          "version": "2.0.0",
+          "commit": "e13c89fb24ec98acccff8043bb8c4d4ff9e6342b",
+          "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4318,7 +4318,7 @@
           "commit": "291228ad93c6d8ff4763bc4f2027fe533755cc9c",
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         },
-		{
+        {
           "version": "2.0.0",
           "commit": "e13c89fb24ec98acccff8043bb8c4d4ff9e6342b",
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"


### PR DESCRIPTION
Version update of AquaQ Analytics KDB+ Adaptor Datasource Plugin. 
Includes support for:

- Creating Grafana variables including by querying the connected database.
- Using Grafana variables with the ${varname} syntax in custom free-form queries or using the query-builder. 
- Some Grafana global variables e.g. __from, __to, __interval, url variables.

Details for how to set up an environment to use this plugin have been provided in the Readme.md file.