### PR TITLE
v2.0.0 update for KDB+ Datasource Plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4317,6 +4317,11 @@
           "version": "1.0.1",
           "commit": "291228ad93c6d8ff4763bc4f2027fe533755cc9c",
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
+        },
+		{
+          "version": "2.0.0",
+          "commit": "e13c89fb24ec98acccff8043bb8c4d4ff9e6342b",
+          "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4318,7 +4318,7 @@
           "commit": "291228ad93c6d8ff4763bc4f2027fe533755cc9c",
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
         },
-		{
+        {
           "version": "2.0.0",
           "commit": "e13c89fb24ec98acccff8043bb8c4d4ff9e6342b",
           "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"

--- a/repo.json
+++ b/repo.json
@@ -4320,8 +4320,13 @@
         },
         {
           "version": "2.0.0",
-          "commit": "e13c89fb24ec98acccff8043bb8c4d4ff9e6342b",
-          "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws"
+          "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws",
+          "download":{
+            "any": {
+              "url": "https://github.com/AquaQAnalytics/grafana-kdb-datasource-ws/raw/v2.0.0/grafana-kdb-datasource-2.0.0.zip",
+              "md5": "31c4fb81bf104f0a6658aff26a7643b1"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
Version 2.0.0 of the KDB+ Datasource Plugin, which includes support for:

- Creating custom Grafana variables by querying a kdb+ database
- Utilising Grafana variables in both custom queries and in the query builder
- Several global variables are also usable in queries including __from, __to, __interval

Installation details and details of how to set up a suitable kdb environment are provided in Readme.md