### PR TITLE
Bump Annunciator panel plugin to v1.1.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2465,7 +2465,7 @@
           "download": {
             "any": {
               "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel/archive/v1.1.0.zip",
-              "md5": "2f974f20029a10990a67b7da347b5cd5"
+              "md5": "5DB2AF489A087BBA9C0CD490F80A7E45"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -2459,34 +2459,15 @@
       "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel",
       "versions": [
         {
-          "version": "1.0.0",
-          "commit": "542707e504b1461bb6fb70b86c8a637f93724181",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
-        },
-        {
-          "version": "1.0.2",
-          "commit": "dfc33b15a6f3663be7b840197b22b3c2865c9ae5",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
-        },
-        {
-          "version": "1.0.3",
-          "commit": "cc8e7fdb9b1f058c560376abbfd4c4d4888b4695",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
-        },
-        {
-          "version": "1.0.4",
-          "commit": "b17afff7b7ac1e923b71485e004fe376558ff21f",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
-        },
-        {
-          "version": "1.0.5",
-          "commit": "3796550c2d733b777f85f1536b086b1ade33b75b",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
-        },
-        {
           "version": "1.1.0",
           "commit": "43d1cf3a687ec1f2e59e52044f96ef66d4a85960",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel/archive/v1.1.0.zip",
+              "md5": "2f974f20029a10990a67b7da347b5cd5"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2465,7 +2465,7 @@
           "download": {
             "any": {
               "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel/archive/v1.1.0.zip",
-              "md5": "5DB2AF489A087BBA9C0CD490F80A7E45"
+              "md5": "5db2af489a087bba9c0cd490f80a7e45"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -2482,6 +2482,11 @@
           "version": "1.0.5",
           "commit": "3796550c2d733b777f85f1536b086b1ade33b75b",
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+        },
+        {
+          "version": "1.1.0",
+          "commit": "43d1cf3a687ec1f2e59e52044f96ef66d4a85960",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2459,6 +2459,31 @@
       "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel",
       "versions": [
         {
+          "version": "1.0.0",
+          "commit": "542707e504b1461bb6fb70b86c8a637f93724181",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+        },
+        {
+          "version": "1.0.2",
+          "commit": "dfc33b15a6f3663be7b840197b22b3c2865c9ae5",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+        },
+        {
+          "version": "1.0.3",
+          "commit": "cc8e7fdb9b1f058c560376abbfd4c4d4888b4695",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+        },
+        {
+          "version": "1.0.4",
+          "commit": "b17afff7b7ac1e923b71485e004fe376558ff21f",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+        },
+        {
+          "version": "1.0.5",
+          "commit": "3796550c2d733b777f85f1536b086b1ade33b75b",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel"
+        },
+        {
           "version": "1.1.0",
           "commit": "43d1cf3a687ec1f2e59e52044f96ef66d4a85960",
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel",

--- a/repo.json
+++ b/repo.json
@@ -2464,8 +2464,8 @@
           "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel",
           "download": {
             "any": {
-              "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel/archive/v1.1.0.zip",
-              "md5": "5db2af489a087bba9c0cd490f80a7e45"
+              "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel/releases/download/v1.1.0/michaeldmoore-annunciator-panel-1.1.0.zip",
+              "md5": "2f974f20029a10990a67b7da347b5cd5"
             }
           }
         }


### PR DESCRIPTION
This is the first attempt using the new toolkit workflow, so let's hope I got this right.

```
{
  "id": "michaeldmoore-annunciator-panel",
  "type": "panel",
  "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel",
  "versions": [
    {
      "version": "1.1.0",
      "commit": "43d1cf3a687ec1f2e59e52044f96ef66d4a85960",
      "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel",
      "download": {
        "any": {
          "url": "https://github.com/michaeldmoore/michaeldmoore-annunciator-panel/releases/download/untagged-27ef6f822e34e578f271/michaeldmoore-annunciator-panel-1.1.0.zip",
          "md5": "2f974f20029a10990a67b7da347b5cd5"
        }
      }
    }
  ]
}
```
