### PR TITLE
Initial (re) release of new community scatter panel plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3503,8 +3503,8 @@
           "url": "https://github.com/michaeldmoore/michaeldmoore-scatter-panel",
           "download": {
             "any": {
-              "url": "https://github.com/michaeldmoore/michaeldmoore-scatter-panel/archive/v1.0.0.zip",
-              "md5": "f021d6bcd3801a43b61d7c5ef2e14ac0"
+              "url": "https://github.com/michaeldmoore/michaeldmoore-scatter-panel/releases/download/v1.0.0/michaeldmoore-scatter-panel-1.0.0.zip",
+              "md5": "3b278c8d1bf4f73e2c553d8c47d55a6f"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -3493,6 +3493,18 @@
       ]
     },
     {
+      "id": "michaeldmoore-scatter-panel",
+      "type": "panel",
+      "url": "https://github.com/michaeldmoore/michaeldmoore-scatter-panel",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "cb7dc09d9b46a691ef7b6eb7c32bd57a73fb44b0",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-scatter-panel"
+        }
+      ]
+    },
+    {
       "id": "scadavis-synoptic-panel",
       "type": "panel",
       "url": "https://github.com/riclolsen/scadavis-synoptic-panel",

--- a/repo.json
+++ b/repo.json
@@ -3500,7 +3500,13 @@
         {
           "version": "1.0.0",
           "commit": "cb7dc09d9b46a691ef7b6eb7c32bd57a73fb44b0",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-scatter-panel"
+          "url": "https://github.com/michaeldmoore/michaeldmoore-scatter-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/michaeldmoore/michaeldmoore-scatter-panel/archive/v1.0.0.zip",
+              "md5": "f021d6bcd3801a43b61d7c5ef2e14ac0"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
This time, revised to use the github release workflow-generated request snippet

```
{
  "id": "michaeldmoore-scatter-panel",
  "type": "panel",
  "url": "https://github.com/michaeldmoore/michaeldmoore-scatter-panel",
  "versions": [
    {
      "version": "1.0.0",
      "commit": "cb7dc09d9b46a691ef7b6eb7c32bd57a73fb44b0",
      "url": "https://github.com/michaeldmoore/michaeldmoore-scatter-panel",
      "download": {
        "any": {
          "url": "https://github.com/michaeldmoore/michaeldmoore-scatter-panel/releases/download/untagged-3fd9a743522dab2e4a42/michaeldmoore-scatter-panel-1.0.0.zip",
          "md5": "3b278c8d1bf4f73e2c553d8c47d55a6f"
        }
      }
    }
  ]
}
```

Note - I will be deleting the previously created PR832.  The code is the same, but now relies on the github release workflow with no manual intervention (yay!)