### PR TITLE
Update Multistat to v1.7.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3470,6 +3470,66 @@
       "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel",
       "versions": [
         {
+          "version": "1.1.0",
+          "commit": "d34709e5ee7bddcdd93cbf8dbf31ce8b9e02d056",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.0",
+          "commit": "f514b203f40187000a134cce5696a85a8ae0c72a",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.1",
+          "commit": "1ae5a949e27b1babf111b6f7018f07cbd4d5f603",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.2",
+          "commit": "ea58834449f7ac206fff856d05c96bc0e7238c16",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.3",
+          "commit": "0f4f9a6648ddbf6ac761359ea8bc9893aaed9038",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.4",
+          "commit": "314dea6894a3d3565e71fc06453811525b2258a6",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.5",
+          "commit": "168e6456f3372ba17c46d12d5e531f27f2c3a96b",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.6",
+          "commit": "032789dd8ffc877ec88b7dbbdcc8f9cb45569dbe",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.2.7",
+          "commit": "6fdfbb54d20cc9bd61fd12fb3db7c0cbccfde1d4",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.3.0",
+          "commit": "195691d6cfc42b50ee55210d5bb2f418b046f0aa",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.4.0",
+          "commit": "20b6f3a04e49b32c8d3ca66796426eff83738f1b",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
+          "version": "1.4.1",
+          "commit": "eb7c20fe699a0cbb84a6e37a8039ec7bfca9afb8",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+        },
+        {
           "version": "1.7.1",
           "commit": "c7b55086685c24d4aba964ed30681387ec7bd67c",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel",

--- a/repo.json
+++ b/repo.json
@@ -3470,13 +3470,13 @@
       "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel",
       "versions": [
         {
-          "version": "1.7.0",
-          "commit": "8b1240b9ef6f750f74b15a3b9ee1f529efe9d0d5",
+          "version": "1.7.1",
+          "commit": "c7b55086685c24d4aba964ed30681387ec7bd67c",
           "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel",
           "download": {
             "any": {
-              "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel/archive/v1.7.0.zip",
-              "md5": "212181962a9835005a3c11ddb28d90d0"
+              "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel/releases/download/v1.7.1/michaeldmoore-multistat-panel-1.7.1.zip",
+              "md5": "b1550875bea82e370fe2cd20752f0de8"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -3470,64 +3470,15 @@
       "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel",
       "versions": [
         {
-          "version": "1.1.0",
-          "commit": "d34709e5ee7bddcdd93cbf8dbf31ce8b9e02d056",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
-        },
-        {
-          "version": "1.2.0",
-          "commit": "f514b203f40187000a134cce5696a85a8ae0c72a",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
-        },
-        {
-          "version": "1.2.1",
-          "commit": "1ae5a949e27b1babf111b6f7018f07cbd4d5f603",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
-        },
-        {
-          "version": "1.2.2",
-          "commit": "ea58834449f7ac206fff856d05c96bc0e7238c16",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
-        },
-        {
-          "version": "1.2.3",
-          "commit": "0f4f9a6648ddbf6ac761359ea8bc9893aaed9038",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
-        },
-        {
-          "version": "1.2.4",
-          "commit": "314dea6894a3d3565e71fc06453811525b2258a6",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
-        },
-        {
-          "version": "1.2.5",
-          "commit": "168e6456f3372ba17c46d12d5e531f27f2c3a96b",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
-        },
-        {
-          "version": "1.2.6",
-          "commit": "032789dd8ffc877ec88b7dbbdcc8f9cb45569dbe",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
-        },
-        {
-          "version": "1.2.7",
-          "commit": "6fdfbb54d20cc9bd61fd12fb3db7c0cbccfde1d4",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
-        },
-        {
-          "version": "1.3.0",
-          "commit": "195691d6cfc42b50ee55210d5bb2f418b046f0aa",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
-        },
-        {
-          "version": "1.4.0",
-          "commit": "20b6f3a04e49b32c8d3ca66796426eff83738f1b",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
-        },
-        {
-          "version": "1.4.1",
-          "commit": "eb7c20fe699a0cbb84a6e37a8039ec7bfca9afb8",
-          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel"
+          "version": "1.7.0",
+          "commit": "8b1240b9ef6f750f74b15a3b9ee1f529efe9d0d5",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel/archive/v1.7.0.zip",
+              "md5": "212181962a9835005a3c11ddb28d90d0"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
This version adds label and group renaming, plus reformatting date/time field in-place

Released using new github workflow
