### PR TITLE
Update Redis Data Source 1.3.1 to support streaming and Node Graph in Grafana 7.4

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2996,7 +2996,7 @@
               "md5": "6e4e3c4743cbf677cfcb5cc1c15dd7d8"
             }
           }
-        }  
+        }
       ]
     },
     {
@@ -5179,6 +5179,17 @@
             "any": {
               "url": "https://github.com/RedisGrafana/grafana-redis-datasource/releases/download/v1.3.0/redis-datasource-1.3.0.zip",
               "md5": "a2ec06c3a98fcb51b02bb961c876045a"
+            }
+          }
+        },
+        {
+          "version": "1.3.1",
+          "commit": "4386c2ae3b74b0cb461164dfba48eb2bf6e95657",
+          "url": "https://github.com/RedisGrafana/grafana-redis-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-datasource/releases/download/v1.3.1/redis-datasource-1.3.1.zip",
+              "md5": "7a36a13966c11cf12316422361376cc0"
             }
           }
         }


### PR DESCRIPTION
@marcusolsson Please review and add a new version of Redis Data Source 1.3.1.

To start docker-compose with test database please do: `npm run start:dev`

### Features / Enhancements

- Add Unit test for Golang Backend #119
- Remove "Unknown command" error from response for custom panels #125
- Update Radix to 3.7.0 and other backend dependencies #128
- Redis client, unit-tests refactoring and new unit-tests. #129
- Implement CLI-mode similar to Redis-cli #135
- Added support for errorstats features coming in redis 6.2; Extended commandstats fields with failedCalls and rejectedCalls #137
- Add command to support the panel to show the biggest keys (TMSCAN) #133
- Add RedisGears commands (RG.PYSTATS, RG.DUMPREGISTRATIONS, RG.PYEXECUTE) #136
- Implement XRANGE and XREVRANGE commands #148
- Add Client Type tooltip #149
- Refactoring Query Editor #151
- Add handling different frame type for Streaming data source #152
- Update tooltip for RedisTimeSeries Label Filter #155
- Update Loading state for Streaming for Grafana 7.4 #158
- Update Grafana SDK 0.86 to fix race conditions #160
- Add Redis Graph module (GRAPH.QUERY, GRAPH.SLOWLOG) #157

### Bug fixes

- Experiencing memory leak in Grafana docker seemingly stemming from this plugin #116
- All Redis Datasource timeout when one is not reachable #73

![Screen Shot 2021-02-04 at 10 48 21 PM](https://user-images.githubusercontent.com/47795110/106999925-ece39000-673b-11eb-91b0-503a0301032f.png)
