### PR TITLE
Apache Cassandra Datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -5493,6 +5493,23 @@
           }
         }
       ]
+    },
+    {
+      "id": "hadesarchitect-cassandra-datasource",
+      "type": "datasource",
+      "url": "https://github.com/HadesArchitect/GrafanaCassandraDatasource",
+      "versions": [
+        {
+          "version": "0.4.2",
+          "url": "https://github.com/HadesArchitect/GrafanaCassandraDatasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/HadesArchitect/GrafanaCassandraDatasource/releases/download/0.4.2/cassandra-datasource-0.4.2.zip",
+              "md5": "e63658303be3f4cc3d40ec385f25094f"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -6180,6 +6180,23 @@
           }
         }
       ]
+    },
+    {
+      "id": "hadesarchitect-cassandra-datasource",
+      "type": "datasource",
+      "url": "https://github.com/HadesArchitect/GrafanaCassandraDatasource",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "url": "https://github.com/HadesArchitect/GrafanaCassandraDatasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/HadesArchitect/GrafanaCassandraDatasource/releases/download/1.0.0/cassandra-datasource-1.0.0.zip",
+              "md5": "32b9e40212cff3b9a3f58658b7072568"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds the datasource plugin to support Apache Cassandra and CQL-compatible databases (DataStax Enterprise, AWS Keyspaces, etc.)

### Resources

* [Main repository](https://github.com/HadesArchitect/GrafanaCassandraDatasource)
* [User Guide](https://github.com/HadesArchitect/GrafanaCassandraDatasource/wiki/User-Guide)
* [Developer Guide](https://github.com/HadesArchitect/GrafanaCassandraDatasource/wiki/Developer-Guide)

### Test Environment

* Please follow the [Quick Demo](https://github.com/HadesArchitect/GrafanaCassandraDatasource/wiki/Quick-Demo) steps.