### PR TITLE
Update gapit-htmlgraphics-panel to v1.3.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -5467,6 +5467,17 @@
               "md5": "546f08335ccf4f73e38b1d669dc0687e"
             }
           }
+        },
+        {
+          "version": "1.3.0",
+          "commit": "777d3f936ee1d2e926e29e701d3b8a788e12542a",
+          "url": "https://github.com/gapitio/gapit-htmlgraphics-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/gapitio/gapit-htmlgraphics-panel/releases/download/v1.3.0/gapit-htmlgraphics-panel-1.3.0.zip",
+              "md5": "fd9e8a320a5605ee52df4c9301e34950"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -5469,13 +5469,13 @@
           }
         },
         {
-          "version": "1.3.0",
-          "commit": "777d3f936ee1d2e926e29e701d3b8a788e12542a",
+          "version": "1.3.1",
+          "commit": "385da3cf551631e4c16d3c045e2da420129f13a0",
           "url": "https://github.com/gapitio/gapit-htmlgraphics-panel",
           "download": {
             "any": {
-              "url": "https://github.com/gapitio/gapit-htmlgraphics-panel/releases/download/v1.3.0/gapit-htmlgraphics-panel-1.3.0.zip",
-              "md5": "fd9e8a320a5605ee52df4c9301e34950"
+              "url": "https://github.com/gapitio/gapit-htmlgraphics-panel/releases/download/v1.3.1/gapit-htmlgraphics-panel-1.3.1.zip",
+              "md5": "2e650d2ced1a4811f0f030474e9b68b5"
             }
           }
         }


### PR DESCRIPTION
Update v1.3.0 for [gapit-htmlgraphics-panel](https://github.com/gapitio/gapit-htmlgraphics-panel/tree/main)

This update fixes an issue where the panel options didn't update when importing/changing values in the "Import/Export" option.
onpanelupdate events has been added to make it easier to integrate React and Svelte into the panel 
Here is the [docs](https://github.com/gapitio/gapit-htmlgraphics-panel/tree/v1.3.0#react) and an [example](https://github.com/gapitio/htmlgraphics-react-radar)(example is a little outdated, but the general is there) with react.
If you use the example in grafana remember to add some metrics (inside-monday -> inside-friday) and (outside-monday -> outside-friday)

Also a huge update to the file naming and the code. A lot of the code has been made simplier and more organized.

## v1.3.0 (2021-02-11)

- **onInit**: Add onpanelupdate events, dynamicData option, and "Trigger panelupdate when mounted" option [#10](https://github.com/gapitio/gapit-htmlgraphics-panel/pull/10)

### Bug fixes

- **Import/Export**: Fix panel options not updating when importing/changing values in the import option [#13](https://github.com/gapitio/gapit-htmlgraphics-panel/pull/13)
