### PR TITLE
Update sskgo-perfcurve-panel to v1.4.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -15,6 +15,17 @@
               "md5": "4fb0c610e5a1c7ba1d0ca8549fbde2ef"
             }
           }
+        },
+        {
+          "version": "1.4.0",
+          "commit": "9f3e86b2c6d59677e75ad4c357cdea3947231e09",
+          "url": "https://github.com/SSKGo/perfcurve-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/SSKGo/perfcurve-panel/releases/download/v1.4.0/sskgo-perfcurve-panel-1.4.0.zip",
+              "md5": "fb59cf8f264050da9e5ac42a1f8ed829"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
I created this pull request because the plugin (sskgo-perfcurve-panel) raise error in Grafana 7.4.X. (Until 7.3.X, no problem happened.)
In order to solve the problem, I updated the plugin for Grafana 7.4.X and released the new version.

Please kindly accept this pull request to let people reach the new version in Grafana's official catalog.
If you have any question, please feel free to contact me.

![image](https://user-images.githubusercontent.com/54466390/107873146-8278df80-6ef3-11eb-9862-6d2e6405891d.png)
