### PR TITLE
Update flant-statusmap-panel version to 0.4.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3415,6 +3415,17 @@
           "version": "0.3.4",
           "commit": "021633670a3deaf85505154bf8b8e961e72cc48f",
           "url": "https://github.com/flant/grafana-statusmap"
+        },
+        {
+          "version": "0.4.1",
+          "commit": "f90015723a9d63020cb76378972f69e74b3022bb",
+          "url": "https://github.com/flant/grafana-statusmap",
+          "download": {
+            "any": {
+              "url": "https://github.com/flant/grafana-statusmap/releases/download/v0.4.1/flant-statusmap-panel-0.4.1.zip",
+              "md5": "dffb2faa880e3535903bb1486ae3cf98"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
Hello! This is the first signed release. Some new features and fix to work in Grafana 7.4.