### PR TITLE
Update Chaos Mesh Data Source

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4505,13 +4505,13 @@
       "url": "https://github.com/chaos-mesh/chaos-mesh-datasource",
       "versions": [
         {
-          "version": "0.2.0",
-          "commit": "4b3c874dbf83fa16a22595b19e37e56bd3c0e8fc",
+          "version": "0.2.1",
+          "commit": "6640fcebed0bbbd95ae8a4ba11e8c0d298b2700a",
           "url": "https://github.com/chaos-mesh/chaos-mesh-datasource",
           "download": {
             "any": {
-              "url": "https://github.com/chaos-mesh/chaos-mesh-datasource/releases/download/v0.2.0/yeya24-chaosmesh-datasource-0.2.0.zip",
-              "md5": "e3bed489808a13721d9701ebe651d55a"
+              "url": "https://github.com/chaos-mesh/chaos-mesh-datasource/releases/download/v0.2.1/yeya24-chaosmesh-datasource-0.2.1.zip",
+              "md5": "62f268dd633de72b685283c7f1475ce0"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -5670,13 +5670,13 @@
       "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource",
       "versions": [
         {
-          "version": "0.1.0",
-          "commit": "316d2ba7c9c1eeabf5b46723f31e268f841243ee",
+          "version": "0.1.1",
+          "commit": "e15f6db092a55fee8dfd45d922dd9dc1457f2728",
           "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource",
           "download": {
             "any": {
-              "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource/releases/download/v0.1.0/g1eny0ung-chaosmesh-datasource-0.1.0.zip",
-              "md5": "67d630b06badcd3458782d515d6007bb"
+              "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource/releases/download/v0.1.1/g1eny0ung-chaosmesh-datasource-0.1.1.zip",
+              "md5": "eddf8df0d654a77559dddca1e753ad88"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -4505,13 +4505,13 @@
       "url": "https://github.com/chaos-mesh/chaos-mesh-datasource",
       "versions": [
         {
-          "version": "0.2.1",
-          "commit": "6640fcebed0bbbd95ae8a4ba11e8c0d298b2700a",
+          "version": "0.2.2",
+          "commit": "a9b355d2c1c3188f7a5e177478cba02adef345fc",
           "url": "https://github.com/chaos-mesh/chaos-mesh-datasource",
           "download": {
             "any": {
-              "url": "https://github.com/chaos-mesh/chaos-mesh-datasource/releases/download/v0.2.1/yeya24-chaosmesh-datasource-0.2.1.zip",
-              "md5": "62f268dd633de72b685283c7f1475ce0"
+              "url": "https://github.com/chaos-mesh/chaos-mesh-datasource/releases/download/v0.2.2/yeya24-chaosmesh-datasource-0.2.2.zip",
+              "md5": "38baa3beb252421034bcf111abb4eaff"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -4505,9 +4505,15 @@
       "url": "https://github.com/chaos-mesh/chaos-mesh-datasource",
       "versions": [
         {
-          "version": "0.1.2",
-          "commit": "d3c31654725fad4efdee98dee5825093763e43a0",
-          "url": "https://github.com/chaos-mesh/chaos-mesh-datasource"
+          "version": "0.2.0",
+          "commit": "4b3c874dbf83fa16a22595b19e37e56bd3c0e8fc",
+          "url": "https://github.com/chaos-mesh/chaos-mesh-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/chaos-mesh/chaos-mesh-datasource/releases/download/v0.2.0/yeya24-chaosmesh-datasource-0.1.3.zip",
+              "md5": "be74ba39c0da7a48335932728f7160f2"
+            }
+          }
         }
       ]
     },
@@ -5659,24 +5665,6 @@
             "any": {
               "url": "https://github.com/thalysantana/grafana-appcenter-datasource/releases/download/v1.0.0/thalysantana-appcenter-datasource-1.0.0.zip",
               "md5": "c1064d6b2463bbff2588c2d9d51a32ba"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": "g1eny0ung-chaosmesh-datasource",
-      "type": "datasource",
-      "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource",
-      "versions": [
-        {
-          "version": "0.1.2",
-          "commit": "9f2b823232d2282aec1b526895c9498042e4d9e0",
-          "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource",
-          "download": {
-            "any": {
-              "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource/releases/download/v0.1.2/g1eny0ung-chaosmesh-datasource-0.1.2.zip",
-              "md5": "2b3536540a638522698f0ba99d0ba299"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -5670,13 +5670,13 @@
       "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource",
       "versions": [
         {
-          "version": "0.1.1",
-          "commit": "e15f6db092a55fee8dfd45d922dd9dc1457f2728",
+          "version": "0.1.2",
+          "commit": "9f2b823232d2282aec1b526895c9498042e4d9e0",
           "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource",
           "download": {
             "any": {
-              "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource/releases/download/v0.1.1/g1eny0ung-chaosmesh-datasource-0.1.1.zip",
-              "md5": "eddf8df0d654a77559dddca1e753ad88"
+              "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource/releases/download/v0.1.2/g1eny0ung-chaosmesh-datasource-0.1.2.zip",
+              "md5": "2b3536540a638522698f0ba99d0ba299"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -2234,7 +2234,6 @@
             }
           }
         }
-
       ]
     },
     {
@@ -5660,6 +5659,24 @@
             "any": {
               "url": "https://github.com/thalysantana/grafana-appcenter-datasource/releases/download/v1.0.0/thalysantana-appcenter-datasource-1.0.0.zip",
               "md5": "c1064d6b2463bbff2588c2d9d51a32ba"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "g1eny0ung-chaosmesh-datasource",
+      "type": "datasource",
+      "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "commit": "316d2ba7c9c1eeabf5b46723f31e268f841243ee",
+          "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/g1eny0ung/grafana-chaos-mesh-datasource/releases/download/v0.1.0/g1eny0ung-chaosmesh-datasource-0.1.0.zip",
+              "md5": "67d630b06badcd3458782d515d6007bb"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -4510,8 +4510,8 @@
           "url": "https://github.com/chaos-mesh/chaos-mesh-datasource",
           "download": {
             "any": {
-              "url": "https://github.com/chaos-mesh/chaos-mesh-datasource/releases/download/v0.2.0/yeya24-chaosmesh-datasource-0.1.3.zip",
-              "md5": "be74ba39c0da7a48335932728f7160f2"
+              "url": "https://github.com/chaos-mesh/chaos-mesh-datasource/releases/download/v0.2.0/yeya24-chaosmesh-datasource-0.2.0.zip",
+              "md5": "e3bed489808a13721d9701ebe651d55a"
             }
           }
         }


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

Hi, all the maintainers. First of all, thank you for all the work you have done in Grafana. I'm one of the committers in [Chaos Mesh](https://github.com/chaos-mesh/chaos-mesh) and open this PR to replace the old Chaos Mesh Data Source plugin.

The brand new Chaos Mesh Data Source fixes the events retrieve with different timezones. It also supports the feature of [Variables](https://grafana.com/docs/grafana/latest/variables/) that can help users to switch different Chaos Experiments quickly.

About how to test, refer to https://chaos-mesh.org/docs/get_started/get_started_on_minikube to bootstrap a test environment with [minikube](https://minikube.sigs.k8s.io/). The below content is example steps:

```sh
minikube start
curl -sSL https://mirrors.chaos-mesh.org/latest/install.sh | bash
kubectl create deployment echoserver --image=k8s.gcr.io/echoserver:1.10
kubectl port-forward -n chaos-testing svc/chaos-dashboard 2333:2333
```

Finally, fill `http://localhost:2333` into `url` and create a Chaos Experiment in Chaos Dashboard (`http://localhost:2333`) to test.

Or apply the below YAML file directly to create an experiment (Pod Kill):

```yaml
apiVersion: chaos-mesh.org/v1alpha1
kind: PodChaos
metadata:
  name: pod-kill-example
  namespace: default
spec:
  action: pod-kill
  mode: one
  selector:
    namespaces:
      - default
  scheduler:
    cron: '@every 30m'
```

