### PR TITLE
Add Performance Co-Pilot plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2810,6 +2810,15 @@
           "version": "0.0.8",
           "commit": "7a541804bd0eb9f57797cf6a5dd0b6aa5bdd8ed8",
           "url": "https://github.com/camptocamp/grafana-prometheus-alertmanager-datasource"
+        },
+        {
+          "version": "1.0.0",
+          "download": {
+            "any": {
+              "url": "https://github.com/camptocamp/grafana-prometheus-alertmanager-datasource/releases/download/1.0.0/camptocamp-prometheus-alertmanager-datasource-1.0.0.zip",
+              "md5": "740480ba9045c35795fb36db84ba4f06"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -265,6 +265,17 @@
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
         {
+          "version": "4.1.5",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix",
+          "commit": "54d46f81bb635d45fb182bc751ea994e7ea85cee",
+          "download": {
+            "any": {
+              "url": "https://github.com/alexanderzobnin/grafana-zabbix/releases/download/v4.1.5/alexanderzobnin-zabbix-app-4.1.5.zip",
+              "md5": "87f7bf416e320877833cd070f56c71ce"
+            }
+          }
+        },
+        {
           "version": "4.1.4",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix",
           "commit": "e77990f9413bae4c7b5b9124c6154dec9d6af811",

--- a/repo.json
+++ b/repo.json
@@ -3881,7 +3881,18 @@
               "md5": "b1550875bea82e370fe2cd20752f0de8"
             }
           }
-        }
+        },
+        {
+          "version": "1.7.2",
+          "commit": "464ba6f95895308537a6cc268c5e0d76e8c1dbc3",
+          "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/michaeldmoore/michaeldmoore-multistat-panel/releases/download/v1.7.2/michaeldmoore-multistat-panel-1.7.2.zip",
+              "md5": "e3858295a0cc0fb1be76cf0ba34474bf"
+            }
+          }
+        }        
       ]
     },
     {

--- a/repo.json
+++ b/repo.json
@@ -4874,6 +4874,24 @@
           "version": "1.1.3",
           "commit": "e188d5ffacb4f266d2f92f50a9bbe8701f10926d",
           "url": "https://github.com/raulsperoni/magnesium-wordcloud-panel"
+        },
+        {
+          "id": "magnesium-wordcloud-panel",
+          "type": "panel",
+          "url": "https://github.com/raulsperoni/magnesium-wordcloud-panel",
+          "versions": [
+            {
+              "version": "1.2.4",
+              "commit": "359a0a1f4c869f1ff5dff45e77e70fcb73544ecf",
+              "url": "https://github.com/raulsperoni/magnesium-wordcloud-panel",
+              "download": {
+                "any": {
+                  "url": "https://github.com/raulsperoni/magnesium-wordcloud-panel/releases/download/v1.2.4/magnesium-wordcloud-panel-1.2.4.zip",
+                  "md5": "51a24506b3a21499bf35f45325a49466"
+                }
+              }
+            }
+          ]
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3753,6 +3753,16 @@
               "md5": "f978400a2dba45782c31161615a2f9dc"
             }
           }
+        },
+        {
+          "version": "2.0.3",
+          "url": "https://github.com/LucasArona/larona-epict-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/LucasArona/larona-epict-panel/releases/download/v2.0.3/larona-epict-panel-2.0.3.zip",
+              "md5": "e22513271e3c031d44ad5870491261fd"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6823,6 +6823,24 @@
           }
         }
       ]
-    }
+    },
+    {
+      "id": "innius-grpc-datasource",
+      "type": "datasource",
+      "url": "https://github.com/innius/grafana-simple-grpc-datasource",
+      "versions": [
+        {
+          "version": "1.0.2",
+          "commit": "8de81e04eb27c2460e2c3337b0ad56d52252690d",
+          "url": "https://github.com/innius/grafana-simple-grpc-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/innius/grafana-simple-grpc-datasource/releases/download/v1.0.2/innius-grpc-datasource-1.0.2.zip",
+              "md5": "1fdfb86c320b1abdb261d1d5389aa158"
+            }
+          }
+        }
+      ]
+    }    
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -4412,6 +4412,16 @@
               "md5": "55c3c09bb929cd41d0a43d6d5d8f2d37"
             }
           }
+        },
+        {
+          "version": "2.0.2",
+          "url": "https://github.com/doitintl/bigquery-grafana",
+          "download": {
+            "any": {
+              "url": "https://github.com/doitintl/bigquery-grafana/releases/download/2.0.2/doitintl-bigquery-datasource-2.0.2.zip",
+              "md5": "ff967b1ba0bdc7a31d9153da7eddd243"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -166,6 +166,17 @@
           "version": "0.0.8",
           "commit": "690d4ffe0753125b64e52a5f5a88f11bf37ca33f",
           "url": "https://github.com/ACE-IoT-Solutions/ace-svg-react"
+        },
+        {
+          "version": "0.0.10",
+          "url": "https://github.com/ACE-IoT-Solutions/ace-svg-react",
+          "commit": "13a99ae0e7b0199d131d47e48f77799e4d6bd6a8",
+          "download": {
+            "any": {
+              "url": "https://github.com/ACE-IoT-Solutions/ace-svg-react/releases/download/v0.0.10-alpha/Plugin.zip",
+              "md5": "46f14170a4b1972156a6cd064ccd464b"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2364,6 +2364,17 @@
               "md5": "bcebceb6f248194b6cc51fec118bd425"
             }
           }
+        },
+        {
+          "version": "2.3.1",
+          "commit": "7449aac7ad992aefb733f36ba13f4343c699ecc2",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana",
+          "download": {
+            "any": {
+              "url": "https://github.com/Vertamedia/clickhouse-grafana/releases/download/v2.3.1/vertamedia-clickhouse-datasource-2.3.1.zip",
+              "md5": "cfef9af53b1ca05fa89efe00c1a7e1a8"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6331,6 +6331,24 @@
           }
         }
       ]
+    },
+        {
+      "id": "bmchelix-ade-datasource",
+      "type": "datasource",
+      "url": "https://github.com/bmcsoftware/bmchelix-datasource",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "13c2d647189433e00da27d79f4c56e15759c1b40",
+          "url": "https://github.com/bmcsoftware/bmchelix-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/bmcsoftware/bmchelix-datasource/releases/download/v1.0.0/bmchelix-ade-datasource-v1.0.0.zip",
+              "md5": "8575e8d53de5ec3af44e7f68c2a9f8c4"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -4430,7 +4430,7 @@
           "download": {
             "any": {
               "url": "https://github.com/doitintl/bigquery-grafana/releases/download/2.0.2/doitintl-bigquery-datasource-2.0.2.zip",
-              "md5": "ff967b1ba0bdc7a31d9153da7eddd243"
+              "md5": "a7c1ee373582e2264004408d0de17a4b"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -6849,12 +6849,12 @@
       "versions": [
         {
           "version": "1.2.0",
-          "commit": "de548433038f9f819782bb629830d528f3f8d5dc",
+          "commit": "2e92d79d453efeb6080da15e33b86aae76723968",
           "url": "https://github.com/grafadruid/druid-grafana",
           "download": {
             "any": {
               "url": "https://github.com/grafadruid/druid-grafana/releases/download/v1.2.0/grafadruid-druid-datasource-1.2.0.zip",
-              "md5": "ee7baf7c61c64ebeccc785faa7d5ec6f"
+              "md5": "2a7f35dae47f6d7a9c4f7a6fb1fc96c8"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -6190,6 +6190,17 @@
               "md5": "b9ef34794a5e38af5b0c40c60811e2a1"
             }
           }
+        },
+        {
+          "version": "2.0.0",
+          "commit": "3b944105fc03e3c9b8c37072dffb7605c2edd210",
+          "url": "https://github.com/RedisGrafana/grafana-redis-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-app/releases/download/v2.0.0/redis-app-2.0.0.zip",
+              "md5": "ce3cf2b50a8a9b673bbd4823183e1683"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6376,7 +6376,18 @@
           "download": {
             "any": {
               "url": "https://github.com/bmcsoftware/bmchelix-datasource/releases/download/v1.0.0/bmchelix-ade-datasource-v1.0.0.zip",
-              "md5": "8575e8d53de5ec3af44e7f68c2a9f8c4"
+              "md5": "8da459c1fcd302ca523e70be1dce79da"
+            }
+          }
+        },
+        {
+          "version": "1.0.1",
+          "commit": "e2eba23df73806cfd788b46ed38c86099ffca7f0",
+          "url": "https://github.com/bmcsoftware/bmchelix-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/bmcsoftware/bmchelix-datasource/releases/download/v1.0.1/bmchelix-ade-datasource-V1.0.1.zip",
+              "md5": "b14861008657f496fe8135977174667d"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -1479,6 +1479,17 @@
               "md5": "cc79be831520d6c91ba0a6af855b6ef0"
             }
           }
+        },
+        {
+          "version": "1.7.3",
+          "commit": "d96ec15c0934d77726e46dec5e78cd65076fcf26",
+          "url": "https://github.com/jdbranham/grafana-diagram",
+          "download": {
+            "any": {
+              "url": "https://github.com/jdbranham/grafana-diagram/releases/download/v1.7.3/jdbranham-diagram-panel-1.7.3.zip",
+              "md5": "4884311f5b58f029c30fd9529c936f7a"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4099,6 +4099,17 @@
               "md5": "e5c5abcdffa4bfc11504c997a825c37b"
             }
           }
+        },
+        {
+          "version": "1.0.3",
+          "commit": "a7af619f09af9705a38d8794b31bded7ef370eb3",
+          "url": "https://github.com/pierosavi/pierosavi-imageit-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/pierosavi/pierosavi-imageit-panel/releases/download/v1.0.3/pierosavi-imageit-panel-1.0.3.zip",
+              "md5": "b80d59a6f50916c2e586bff57ce98395"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6418,6 +6418,17 @@
               "md5": "61e022b9bf6f2afb2311f983be4a53cb"
             }
           }
+        },
+        {
+          "version": "1.0.7",
+          "commit": "162321f24be088e2b7a1502bd8cd60b67ea84aae",
+          "url": "https://github.com/rajsameer/vertica-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/rajsameer/vertica-datasource/releases/download/v1.0.7/rajsameer-vertica-datasource-1.0.7.zip",
+              "md5": "0d3d44a83b69e78d6d2ca7925df6f8f3"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4284,6 +4284,17 @@
               "md5": "b80d59a6f50916c2e586bff57ce98395"
             }
           }
+        },
+        {
+          "version": "1.0.4",
+          "commit": "6ffa4d5215ccef77ad97e551d75eeb62bc189a80",
+          "url": "https://github.com/pierosavi/pierosavi-imageit-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/pierosavi/pierosavi-imageit-panel/releases/download/v1.0.4/pierosavi-imageit-panel-1.0.4.zip",
+              "md5": "df2a07fe5be8b602dcd67c1078dc3721"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6642,6 +6642,17 @@
               "md5": "511422fc8d50e06c1308dae99d065802"
             }
           }
+        },
+        {
+          "version": "2.0.0",
+          "commit": "a8bc61f858fc8f1617d0eac70339906792a45124",
+          "url": "https://github.com/RedisGrafana/grafana-redis-explorer",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-explorer/releases/download/v2.0.0/redis-explorer-app-2.0.0.zip",
+              "md5": "2a760946a6fc6be59f4f312c8a4bba31"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3021,6 +3021,16 @@
               "md5": "c078be8a503f81237c83b93299773c9d"
             }
           }
+        },
+        {
+          "version": "2.0.0",
+          "url": "https://github.com/fr-ser/grafana-sqlite-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/fr-ser/grafana-sqlite-datasource/releases/download/v2.0.0/frser-sqlite-datasource-2.0.0.zip",
+              "md5": "e7ea9f43d8ba3400e194338c540ec4b1"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6617,6 +6617,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "teamviewer-datasource",
+      "type": "datasource",
+      "url": "https://github.com/teamviewer/grafana-teamviewer-datasource",
+      "versions": [
+        {
+          "version": "1.0.1",
+          "commit": "baa247b65a1ef87486dc9c5dd5d8ac81d8ea679e",
+          "url": "https://github.com/teamviewer/grafana-teamviewer-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/teamviewer/grafana-teamviewer-datasource/releases/download/v1.0.1/teamviewer-datasource-1.0.1.zip",
+              "md5": "d253acb797fa35ca4a0763d70621af37"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -3643,6 +3643,16 @@
               "md5": "7cb517eb289f5e96ce8b8d59adfc070d"
             }
           }
+        },
+        {
+          "version": "0.2.5",
+          "url": "https://github.com/simPod/grafana-json-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/simPod/GrafanaJsonDatasource/releases/download/v0.2.5/simpod-json-datasource.zip",
+              "md5": "ab4a4573a0a768aa11af04f075d0b4d8"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6257,6 +6257,24 @@
       ]
     },
     {
+      "id": "redis-explorer-app",
+      "type": "app",
+      "url": "https://github.com/RedisGrafana/grafana-redis-explorer",
+      "versions": [
+        {
+          "version": "1.1.0",
+          "commit": "df4766e23c4455b4858e64223d10532a8e8b8560",
+          "url": "https://github.com/RedisGrafana/grafana-redis-explorer",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-explorer/releases/download/v1.1.0/redis-explorer-app-1.1.0.zip",
+              "md5": "511422fc8d50e06c1308dae99d065802"
+            }
+          }
+        }
+      ]
+    },
+    {
       "id": "hadesarchitect-cassandra-datasource",
       "type": "datasource",
       "url": "https://github.com/HadesArchitect/GrafanaCassandraDatasource",

--- a/repo.json
+++ b/repo.json
@@ -6841,6 +6841,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "grafadruid-druid-datasource",
+      "type": "datasource",
+      "url": "https://github.com/grafadruid/druid-grafana",
+      "versions": [
+        {
+          "version": "1.2.0",
+          "commit": "de548433038f9f819782bb629830d528f3f8d5dc",
+          "url": "https://github.com/grafadruid/druid-grafana",
+          "download": {
+            "any": {
+              "url": "https://github.com/grafadruid/druid-grafana/releases/download/v1.2.0/grafadruid-druid-datasource-1.2.0.zip",
+              "md5": "ee7baf7c61c64ebeccc785faa7d5ec6f"
+            }
+          }
+        }
+      ]
     }    
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -6198,6 +6198,23 @@
           }
         }
       ]
+    },
+    {
+      "id": "hadesarchitect-cassandra-datasource",
+      "type": "datasource",
+      "url": "https://github.com/HadesArchitect/GrafanaCassandraDatasource",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "url": "https://github.com/HadesArchitect/GrafanaCassandraDatasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/HadesArchitect/GrafanaCassandraDatasource/releases/download/1.0.0/cassandra-datasource-1.0.0.zip",
+              "md5": "32b9e40212cff3b9a3f58658b7072568"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -6597,16 +6597,16 @@
       "url": "https://github.com/performancecopilot/grafana-pcp",
       "versions": [
         {
-          "version": "3.0.3",
-          "commit": "9c4d1339e9efee6491d418913094bbb7b45eadd5",
+          "version": "3.1.0",
+          "commit": "ed42761b5305d1c1c65d95cfc67d80a99fbde9d4",
           "url": "https://github.com/performancecopilot/grafana-pcp",
           "download": {
             "any": {
-              "url": "https://github.com/performancecopilot/grafana-pcp/releases/download/v3.0.3/performancecopilot-pcp-app-3.0.3.zip",
-              "md5": "a103e0031fe02f5845a2ebc51aa083e3"
-	    }
-	  }
-	}
+              "url": "https://github.com/performancecopilot/grafana-pcp/releases/download/v3.1.0/performancecopilot-pcp-app-3.1.0.zip",
+              "md5": "d28483dee7b6408a37492955ad6785bf"
+            }
+          }
+        }
       ]
     },
     {

--- a/repo.json
+++ b/repo.json
@@ -5879,6 +5879,17 @@
           "version": "2.2.0",
           "commit": "408f6a5ab93bebf41d42ccec3e83f68714d2986b",
           "url": "https://github.com/Dalvany/dalvany-image-panel"
+        },
+        {
+          "version": "2.3.0",
+          "commit": "6abaf62c9f2fdd5b551a4490e64ae563f4626aa6",
+          "url": "https://github.com/Dalvany/dalvany-image-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/Dalvany/dalvany-image-panel/releases/download/v2.3.0/dalvany-image-panel-2.3.0.zip",
+              "md5": "6b8e5fdb43639c9e4193214f4dffa356"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6138,6 +6138,17 @@
           "version": "1.0.1",
           "commit": "87879b0db01d13d6be6b637ad6d0e0a47f15bbb4",
           "url": "https://github.com/innius/grafana-video-panel"
+        },
+        {
+          "version": "1.0.4",
+          "commit": "8480ad2c613f8d9988b903c7695bb4fc131d736d",
+          "url": "https://github.com/innius/grafana-video-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/innius/grafana-video-panel/releases/download/v1.0.4/innius-video-panel-1.0.4.zip",
+              "md5": "b74ecafa04f2a1bdb89f1100ceb06031"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -5920,6 +5920,17 @@
               "md5": "2e650d2ced1a4811f0f030474e9b68b5"
             }
           }
+        },
+        {
+          "version": "1.3.3",
+          "commit": "2fbebf5003755b13723fa64bc45ec561443c7ed2",
+          "url": "https://github.com/gapitio/gapit-htmlgraphics-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/gapitio/gapit-htmlgraphics-panel/releases/download/v1.3.3/gapit-htmlgraphics-panel-1.3.3.zip",
+              "md5": "85dd52c31adc6a70690e78a910d52fdb"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6425,6 +6425,16 @@
               "md5": "f5add742c5f760b7e5ed767479e7f7c6"
             }
           }
+        },
+        {
+          "version": "1.0.2",
+          "url": "https://github.com/anodot/grafana-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/anodot/grafana-panel/raw/main/anodot-panel-1.0.2.zip",
+              "md5": "576309b243ad4c1a884f1f33f87c7930"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -5893,6 +5893,17 @@
               "md5": "ca659bafe4230440831f720e335d49ac"
             }
           }
+        },
+        {
+          "version": "1.2.0",
+          "commit": "611261873963d4a6dd8bd55334bafeafaefdca3a",
+          "url": "https://github.com/RedisGrafana/grafana-redis-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-app/releases/download/v1.2.0/redis-app-1.2.0.zip",
+              "md5": "b9ef34794a5e38af5b0c40c60811e2a1"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -141,6 +141,17 @@
               "md5": "52f4d2f2a49451cc02832c35521ce2ef"
             }
           }
+        },
+        {
+          "version": "0.1.5",
+          "commit": "38430fdd74ee541b35113531f5b646b2bbeaaa7a",
+          "url": "https://github.com/faxm0dem/grafana-riemann-websocket-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/faxm0dem/grafana-riemann-websocket-datasource/releases/download/v0.1.5/ccin2p3-riemann-datasource-0.1.5.zip",
+              "md5": "48e77ba849658460a7be2782fb1039df"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -5968,6 +5968,17 @@
               "md5": "ac25cebeea24806123adea98fdf64892"
             }
           }
+        },
+        {
+          "version": "1.5.0",
+          "commit": "772f0c714de229535d1111cc11e64de3bc070d9f",
+          "url": "https://github.com/RedisGrafana/grafana-redis-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-datasource/releases/download/v1.5.0/redis-datasource-1.5.0.zip",
+              "md5": "264f5f776d5f0cf50ea1417ffe4b1bc6"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6400,6 +6400,16 @@
               "md5": "dabfe80110c22ee7ae781273798eb92f"
             }
           }
+        },
+        {
+          "version": "1.0.2",
+          "url": "https://github.com/anodot/grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/anodot/grafana-datasource/raw/main/anodot-datasource-1.0.2.zip",
+              "md5": "b956db345daafabc616e9299c562fcc7"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3942,7 +3942,7 @@
               "md5": "e3858295a0cc0fb1be76cf0ba34474bf"
             }
           }
-        }        
+        }
       ]
     },
     {
@@ -6549,6 +6549,42 @@
             "any": {
               "url": "https://github.com/bmcsoftware/bmchelix-datasource/releases/download/v1.0.1/bmchelix-ade-datasource-V1.0.1.zip",
               "md5": "b14861008657f496fe8135977174667d"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "pyroscope-panel",
+      "type": "panel",
+      "url": "https://github.com/pyroscope-io/grafana-panel-plugin",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "d05ea18ed3cc5ba518052ea7258c324b85b5a9d6",
+          "url": "https://github.com/pyroscope-io/grafana-panel-plugin",
+          "download": {
+            "any": {
+              "url": "https://github.com/pyroscope-io/grafana-panel-plugin/releases/download/v1.0.0/pyroscope-panel-1.0.0.zip",
+              "md5": "f986fbfc5189602b844b4fffc79272b4"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "pyroscope-datasource",
+      "type": "datasource",
+      "url": "https://github.com/pyroscope-io/grafana-datasource-plugin",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "d6abc84d7a7a0cfd4450ed91827f11af93bfc035",
+          "url": "https://github.com/pyroscope-io/grafana-datasource-plugin",
+          "download": {
+            "any": {
+              "url": "https://github.com/pyroscope-io/grafana-datasource-plugin/releases/download/v1.0.0/pyroscope-datasource-1.0.0.zip",
+              "md5": "f40ad1683a1261f93206c76d730388ad"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -1742,6 +1742,11 @@
       "url": "https://github.com/ryantxu/ajax-panel",
       "versions": [
         {
+          "version": "0.1.0",
+          "commit": "cc0cb13f1b662e1a01f7584c6d7d0dd2c136bd18",
+          "url": "https://github.com/ryantxu/ajax-panel"
+        },
+        {
           "version": "0.0.7",
           "commit": "d3605f9dca18d8b4d6a7bc03153d98533eaa61e5",
           "url": "https://github.com/ryantxu/ajax-panel"

--- a/repo.json
+++ b/repo.json
@@ -6114,12 +6114,22 @@
               "md5": "cdee4b59d3967d02b3124ce1ace56157"
             }
           }
+        },
+        {
+          "version": "1.0.1",
+          "url": "https://github.com/anodot/grafana-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/anodot/grafana-panel/raw/main/anodot-panel-1.0.1.zip",
+              "md5": "f5add742c5f760b7e5ed767479e7f7c6"
+            }
+          }
         }
       ]
     },
     {
       "id": "anodot-datasource",
-      "type": "panel",
+      "type": "datasource",
       "url": "https://github.com/anodot/grafana-datasource",
       "versions": [
         {
@@ -6129,6 +6139,16 @@
             "any": {
               "url": "https://github.com/anodot/grafana-datasource/raw/main/anodot-datasource-1.0.0.zip",
               "md5": "13056917de9a0e9af570079cbef33316"
+            }
+          }
+        },
+        {
+          "version": "1.0.1",
+          "url": "https://github.com/anodot/grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/anodot/grafana-datasource/raw/main/anodot-datasource-1.0.1.zip",
+              "md5": "dabfe80110c22ee7ae781273798eb92f"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -73,6 +73,16 @@
               "md5": "a0a877b1c762d7249d4aef42f92f784a"
             }
           }
+        },
+        {
+          "version": "2.2.0",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.2.0/tencentcloud-monitor-app-2.2.0.zip",
+              "md5": "406f39bfab69e5d7eaff0260ab6f6fb4"
+            }
+          }
         }
       ]
     },
@@ -6530,15 +6540,15 @@
           }
         },
         {
-            "version": "0.7.0",
-            "commit": "56b77e534ae79b82cecb7f2cc718fc0efb69b3d4",
-            "url": "https://github.com/yesoreyeram/grafana-infinity-datasource",
-            "download": {
-                "any": {
-                "url": "https://github.com/yesoreyeram/grafana-infinity-datasource/releases/download/v0.7.0/yesoreyeram-infinity-datasource-0.7.0.zip",
-                "md5": "8f27b7cf1904bf86b117f0fd0662f5dd"
-                }
+          "version": "0.7.0",
+          "commit": "56b77e534ae79b82cecb7f2cc718fc0efb69b3d4",
+          "url": "https://github.com/yesoreyeram/grafana-infinity-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/yesoreyeram/grafana-infinity-datasource/releases/download/v0.7.0/yesoreyeram-infinity-datasource-0.7.0.zip",
+              "md5": "8f27b7cf1904bf86b117f0fd0662f5dd"
             }
+          }
         }
       ]
     },
@@ -6577,7 +6587,7 @@
         }
       ]
     },
-        {
+    {
       "id": "bmchelix-ade-datasource",
       "type": "datasource",
       "url": "https://github.com/bmcsoftware/bmchelix-datasource",

--- a/repo.json
+++ b/repo.json
@@ -6294,6 +6294,17 @@
               "md5": "b8b6e1469f1479a4f48e576b59681852"
             }
           }
+        },
+        {
+            "version": "0.7.0",
+            "commit": "56b77e534ae79b82cecb7f2cc718fc0efb69b3d4",
+            "url": "https://github.com/yesoreyeram/grafana-infinity-datasource",
+            "download": {
+                "any": {
+                "url": "https://github.com/yesoreyeram/grafana-infinity-datasource/releases/download/v0.7.0/yesoreyeram-infinity-datasource-0.7.0.zip",
+                "md5": "8f27b7cf1904bf86b117f0fd0662f5dd"
+                }
+            }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4553,6 +4553,25 @@
               "md5": "65504ddc9a2153b7d15af57233dc728a"
             }
           }
+        },
+        {
+          "version": "2.1.0",
+          "commit": "8a00bb2c10c49f94151f4aa456ae393162e3e08e",
+          "url": "https://github.com/grafana/grafana-image-renderer",
+          "download": {
+            "darwin-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v2.1.0/plugin-darwin-x64-unknown.zip",
+              "md5": "7e250629b01c2645d941c898fdeed35d"
+            },
+            "linux-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v2.1.0/plugin-linux-x64-glibc.zip",
+              "md5": "c33d286517d0d50c6118c1c650175283"
+            },
+            "windows-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v2.1.0/plugin-win32-x64-unknown.zip",
+              "md5": "299df0fffbf8f2b38bac026752714345"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -1,6 +1,35 @@
 {
   "plugins": [
     {
+      "id": "streamr-datasource",
+      "type": "datasource",
+      "url": "https://github.com/sergejmueller/streamr-datasource",
+      "versions": [
+        {
+          "version": "1.4.0",
+          "commit": "28eeca4f2eb0000d8923a0d19fcf5bfe158c50fc",
+          "url": "https://github.com/sergejmueller/streamr-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/sergejmueller/streamr-datasource/releases/download/1.4.0/streamr-datasource-1.4.0.zip",
+              "md5": "621c0e82ea805eb3f5c99c4648b4b8c4"
+            }
+          }
+        },
+        {
+          "version": "1.5.0",
+          "commit": "4ec6a1ce232e92b4531dfa1f60ed0669e5c39321",
+          "url": "https://github.com/sergejmueller/streamr-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/sergejmueller/streamr-datasource/releases/download/1.5.0/streamr-datasource-1.5.0.zip",
+              "md5": "e0409092fce329b5fa30abd0a3964f9a"
+            }
+          }
+        }
+      ]
+    },
+    {
       "id": "tencentcloud-monitor-app",
       "type": "app",
       "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",

--- a/repo.json
+++ b/repo.json
@@ -3906,6 +3906,16 @@
               "md5": "e22513271e3c031d44ad5870491261fd"
             }
           }
+        },
+        {
+          "version": "2.0.4",
+          "url": "https://github.com/LucasArona/larona-epict-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/LucasArona/larona-epict-panel/releases/download/2.0.4/larona-epict-panel-2.0.4.zip",
+              "md5": "72a90d3128abafc054ce14f3cbb6d869"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6197,6 +6197,16 @@
               "md5": "94936b31096de4218a9c31f5ab2ab902"
             }
           }
+        },
+        {
+          "version": "0.4.0",
+          "url": "https://github.com/ae3e/ae3e-plotly-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/ae3e/ae3e-plotly-panel/releases/download/v0.4.0/ae3e-plotly-panel-0.4.0.zip",
+              "md5": "bafad6c9c14711f9c72624df398127a2"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -2912,6 +2912,36 @@
               "md5": "776aaf3fbfe3dd9f532dbd1a5e80981a"
             }
           }
+        },
+        {
+          "version": "1.0.3",
+          "url": "https://github.com/fr-ser/grafana-sqlite-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/fr-ser/grafana-sqlite-datasource/releases/download/v1.0.3/frser-sqlite-datasource-1.0.3.zip",
+              "md5": "80838d4cd63d6995a0fa63bd168aa928"
+            }
+          }
+        },
+        {
+          "version": "1.1.0",
+          "url": "https://github.com/fr-ser/grafana-sqlite-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/fr-ser/grafana-sqlite-datasource/releases/download/v1.1.0/frser-sqlite-datasource-1.1.0.zip",
+              "md5": "a644537c69b62e9a9f1561b99f8decdd"
+            }
+          }
+        },
+        {
+          "version": "1.2.0",
+          "url": "https://github.com/fr-ser/grafana-sqlite-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/fr-ser/grafana-sqlite-datasource/releases/download/v1.2.0/frser-sqlite-datasource-1.2.0.zip",
+              "md5": "c078be8a503f81237c83b93299773c9d"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -5664,6 +5664,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "performancecopilot-pcp-app",
+      "type": "app",
+      "url": "https://github.com/performancecopilot/grafana-pcp",
+      "versions": [
+        {
+          "version": "3.0.3",
+          "commit": "9c4d1339e9efee6491d418913094bbb7b45eadd5",
+          "url": "https://github.com/performancecopilot/grafana-pcp",
+          "download": {
+            "any": {
+              "url": "https://github.com/performancecopilot/grafana-pcp/releases/download/v3.0.3/performancecopilot-pcp-app-3.0.3.zip",
+              "md5": "a103e0031fe02f5845a2ebc51aa083e3"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -3223,6 +3223,17 @@
               "md5": "961cf44ff5ee92d25f4c723a5c1d332b"
             }
           }
+        },
+        {
+          "version": "3.3.0",
+          "commit": "6631df7f04241e69b8503e28a4ceff06de2eed5b",
+          "url": "https://github.com/instana/instana-grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/instana/instana-grafana-datasource/releases/download/v3.3.0/instana-datasource-3.3.0.zip",
+              "md5": "4ac7c80f149f0a492657f4aa8d7a2130"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6709,6 +6709,17 @@
               "md5": "c9770dbc434bf4cc1e7d2134dfc99b1a"
             }
           }
+        },
+        {
+          "version": "2.0.0",
+          "commit": "694523b8fbda3500e3110bb37bbfef6bd0a693b5",
+          "url": "https://github.com/VolkovLabs/grafana-image-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/VolkovLabs/grafana-image-panel/releases/download/v2.0.0/volkovlabs-image-panel-2.0.0.zip",
+              "md5": "25fa95780b68370aefa5fe2c4612ffcb"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4675,6 +4675,25 @@
               "md5": "94a250196fd0e13b734334c2c46e114f"
             }
           }
+        },
+        {
+          "version": "3.0.0",
+          "commit": "8491418fe53090abde5f59ad0ca3413f91e798d5",
+          "url": "https://github.com/grafana/grafana-image-renderer",
+          "download": {
+            "darwin-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v3.0.0/plugin-darwin-x64-unknown.zip",
+              "md5": "f111ef722eca2c2a27486744bb4ce162"
+            },
+            "linux-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v3.0.0/plugin-linux-x64-glibc.zip",
+              "md5": "4931eb9df50113d492e3e1507a780f13"
+            },
+            "windows-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v3.0.0/plugin-win32-x64-unknown.zip",
+              "md5": "2171f542ab951d19de6f8e0f19ea34a0"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4694,6 +4694,25 @@
               "md5": "2171f542ab951d19de6f8e0f19ea34a0"
             }
           }
+        },
+        {
+          "version": "3.0.1",
+          "commit": "7a34f24eac6c731f0da40a3f1f5798547cc7556d",
+          "url": "https://github.com/grafana/grafana-image-renderer",
+          "download": {
+            "darwin-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v3.0.1/plugin-darwin-x64-unknown.zip",
+              "md5": "a5deeafc46263696c0ef3f86cb7b12c9"
+            },
+            "linux-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v3.0.1/plugin-linux-x64-glibc.zip",
+              "md5": "69711e70d975153473f3e9df2bb30270"
+            },
+            "windows-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v3.0.1/plugin-win32-x64-unknown.zip",
+              "md5": "17d2ae3560068d015f5b80d6ae3ce29f"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -45,7 +45,6 @@
             }
           }
         }
-
       ]
     },
     {
@@ -5654,6 +5653,17 @@
             "any": {
               "url": "https://github.com/RedisGrafana/grafana-redis-datasource/releases/download/v1.3.1/redis-datasource-1.3.1.zip",
               "md5": "7a36a13966c11cf12316422361376cc0"
+            }
+          }
+        },
+        {
+          "version": "1.4.0",
+          "commit": "ed63cae45ec81eaf8929d65ae2a7f25a299ee58c",
+          "url": "https://github.com/RedisGrafana/grafana-redis-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-datasource/releases/download/v1.4.0/redis-datasource-1.4.0.zip",
+              "md5": "ac25cebeea24806123adea98fdf64892"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -6145,6 +6145,35 @@
             "any": {
               "url": "https://github.com/performancecopilot/grafana-pcp/releases/download/v3.0.3/performancecopilot-pcp-app-3.0.3.zip",
               "md5": "a103e0031fe02f5845a2ebc51aa083e3"
+	    }
+	  }
+	}
+      ]
+    },
+    {
+      "id": "yesoreyeram-infinity-datasource",
+      "type": "datasource",
+      "url": "https://github.com/yesoreyeram/grafana-infinity-datasource",
+      "versions": [
+        {
+          "version": "0.6.0",
+          "commit": "de516a6e3c3aa1a1035ade6069f31a0a47ba7312",
+          "url": "https://github.com/yesoreyeram/grafana-infinity-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/yesoreyeram/grafana-infinity-datasource/releases/download/v0.6.0/yesoreyeram-infinity-datasource-0.6.0.zip",
+              "md5": "91a1545e9ed8ba60e6d7e19db3c31067"
+            }
+          }
+        },
+        {
+          "version": "0.6.1",
+          "commit": "1f332edfb03304ac31b2d4e05f22315bc07e3554",
+          "url": "https://github.com/yesoreyeram/grafana-infinity-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/yesoreyeram/grafana-infinity-datasource/releases/download/v0.6.1/yesoreyeram-infinity-datasource-0.6.1.zip",
+              "md5": "b8b6e1469f1479a4f48e576b59681852"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -6212,6 +6212,17 @@
               "md5": "ce3cf2b50a8a9b673bbd4823183e1683"
             }
           }
+        },
+        {
+          "version": "2.0.1",
+          "commit": "3cafb6de92978a8a76570e7aaec4f6a388c7c33e",
+          "url": "https://github.com/RedisGrafana/grafana-redis-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-app/releases/download/v2.0.1/redis-app-2.0.1.zip",
+              "md5": "1f15042fd1ee52b9ac3b63eb91de90cb"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -34,6 +34,16 @@
               "md5": "930e2d16f0ac9d703b12cfc7a0172ee3"
             }
           }
+        },
+        {
+          "version": "2.1.0",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.1.0/tencentcloud-monitor-app-2.1.0.zip",
+              "md5": "a0a877b1c762d7249d4aef42f92f784a"
+            }
+          }
         }
 
       ]

--- a/repo.json
+++ b/repo.json
@@ -6494,6 +6494,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "volkovlabs-image-panel",
+      "type": "panel",
+      "url": "https://github.com/VolkovLabs/grafana-image-panel",
+      "versions": [
+        {
+          "version": "1.0.1",
+          "commit": "7627e552c46dcd0710f0408ba993f5257be0587e",
+          "url": "https://github.com/VolkovLabs/grafana-image-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/VolkovLabs/grafana-image-panel/releases/download/v1.0.1/volkovlabs-image-panel-1.0.1.zip",
+              "md5": "c9770dbc434bf4cc1e7d2134dfc99b1a"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -6756,6 +6756,23 @@
         }
       ]
     },
+ {
+      "id": "sebastiangunreben-cdf-panel",
+      "type": "panel",
+      "url": "https://github.com/sebastiangunreben/sebastiangunreben-cdf-plugin",
+      "versions": [
+        {
+          "version": "0.2.0",
+          "url": "https://github.com/telekom/sebastiangunreben-cdf-plugin/releases/tag/v0.2.0",
+          "download": {
+            "any": {
+              "url": "https://github.com/telekom/sebastiangunreben-cdf-plugin/releases/download/v0.2.0/sebastiangunreben-cdf-panel-0.2.0.zip",
+              "md5": "c42fcf2b9f8f1590c30a875c504e3420"
+            }
+          }
+        }
+        ]
+},
     {
       "id": "teamviewer-datasource",
       "type": "datasource",

--- a/repo.json
+++ b/repo.json
@@ -1828,6 +1828,11 @@
       "url": "https://github.com/NatelEnergy/grafana-discrete-panel",
       "versions": [
         {
+          "version": "0.1.1",
+          "commit": "2f25cb61a2bb793bb676506ca2c2eaf04f6f0749",
+          "url": "https://github.com/NatelEnergy/grafana-discrete-panel"
+        },
+        {
           "version": "0.1.0",
           "commit": "f434d9f06c77b7676734f10a985627ba03344dad",
           "url": "https://github.com/NatelEnergy/grafana-discrete-panel"

--- a/repo.json
+++ b/repo.json
@@ -6675,6 +6675,17 @@
               "md5": "d253acb797fa35ca4a0763d70621af37"
             }
           }
+        },
+        {
+          "version": "1.0.2",
+          "commit": "69dda723c27840b2c06eb911844d052710a68a09",
+          "url": "https://github.com/teamviewer/grafana-teamviewer-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/teamviewer/grafana-teamviewer-datasource/releases/download/v1.0.2/teamviewer-datasource-1.0.2.zip",
+              "md5": "dc3e553254924bb675336e1fe7a99fc2"
+            }
+          }
         }
       ]
     }

--- a/repo.json
+++ b/repo.json
@@ -5844,6 +5844,16 @@
           "version": "0.2.3",
           "commit": "a59eb13ec63150a1478c325ba976f47bd37b0902",
           "url": "https://github.com/Gowee/traceroute-map-panel"
+        },
+        {
+          "version": "0.3.0",
+          "url": "https://github.com/Gowee/traceroute-map-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/Gowee/traceroute-map-panel/releases/download/v0.3.0-3/dist-v0.3.0-3.zip",
+              "md5": "ad55c08fd0b6248f0c6a0f923c69dc8b"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4838,6 +4838,17 @@
           "version": "1.1.1",
           "commit": "fb38ba704e582b2cefd3d2efea837ca9fc865af3",
           "url": "https://github.com/MacroPower/macropower-analytics-panel"
+        },
+        {
+          "version": "2.0.0",
+          "commit": "1fbc2f9191cdcb2e002b42af64347ccd244684f9",
+          "url": "https://github.com/MacroPower/macropower-analytics-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/MacroPower/macropower-analytics-panel/releases/download/v2.0.0/macropower-analytics-panel-2.0.0.zip",
+              "md5": "1fba4f9f0c09a6f84c610626c86a221b"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4215,6 +4215,17 @@
               "md5": "3d744164de2cf59266be0777a9395afb"
             }
           }
+        },
+        {
+          "version": "2.3.0",
+          "commit": "6bf56c7b045097643f71a05d264938027214311f",
+          "url": "https://github.com/cognitedata/cognite-grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/cognitedata/cognite-grafana-datasource/releases/download/v2.3.0/cognitedata-datasource-2.3.0.zip",
+              "md5": "af4481e74259ae63c6bb20a311263f13"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4572,6 +4572,25 @@
               "md5": "299df0fffbf8f2b38bac026752714345"
             }
           }
+        },
+        {
+          "version": "2.1.1",
+          "commit": "38a111c50ed8da04d9d74817beb38a53a0e771ee",
+          "url": "https://github.com/grafana/grafana-image-renderer",
+          "download": {
+            "darwin-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v2.1.1/plugin-darwin-x64-unknown.zip",
+              "md5": "187d823fa57e9064447e88f94db810c3"
+            },
+            "linux-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v2.1.1/plugin-linux-x64-glibc.zip",
+              "md5": "fb3907173941980d2acd11487fef4241"
+            },
+            "windows-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v2.1.1/plugin-win32-x64-unknown.zip",
+              "md5": "94a250196fd0e13b734334c2c46e114f"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
This adds the open source [Grafana plugin for Performance Co-Pilot](https://github.com/performancecopilot/grafana-pcp/) - v3.1.0

# Setup Instructions

[Performance Co-Pilot](https://pcp.io) stores historical metric data in a [Redis](https://redis.io) database. To test the datasource, please start the Redis container first, and then the PCP container. The PCP container needs to be started in privileged mode because it uses systemd inside the container.

Once all containers are started, you can enable the plugin and add the new datasources (PCP Redis, PCP Vector) by using the default values and `http://localhost:44322` as the URL. Each datasource includes one or more example dashboards.

# Containers:
```
docker run -d \
  --name redis \
  --network host \
  redis

docker run -d \
  --name pcp \
  --privileged \
  -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
  --network host \
  registry.fedoraproject.org/pcp

docker run -d \
  --name grafana \
  -e GF_INSTALL_PLUGINS="https://github.com/performancecopilot/grafana-pcp/releases/download/v3.1.0/performancecopilot-pcp-app-3.1.0.zip;performancecopilot-pcp-app" \
  --network host \
  grafana/grafana
```
