### PR TITLE
update graphql-datasource to v1.3.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -5524,6 +5524,17 @@
               "md5": "fa82a90a78a225512c33561a178c34c0"
             }
           }
+        },
+        {
+          "version": "1.3.0",
+          "commit": "994dface7e59d454c2b02219bdf07ed13ce6deab",
+          "url": "https://github.com/fifemon/graphql-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/fifemon/graphql-datasource/releases/download/v1.3.0/fifemon-graphql-datasource-1.3.0.zip",
+              "md5": "ac3a065fb9b6ffec42533e58fd3aaa3b"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
A couple [new features](https://github.com/fifemon/graphql-datasource/releases/tag/v1.3.0), including key/value dashboard variables and custom time path and format.

There's also now a Docker-runnable [test server](https://github.com/retzkek/graphql-test-source/) and [sample dashboard](https://grafana.com/grafana/dashboards/14079) to verify functionality.