### PR TITLE
Update Traceroute Map Panel to v0.3.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -5536,6 +5536,11 @@
           "version": "0.2.3",
           "commit": "a59eb13ec63150a1478c325ba976f47bd37b0902",
           "url": "https://github.com/Gowee/traceroute-map-panel"
+        },
+        {
+          "version": "0.3.0",
+          "commit": "277af7e5e38c8669eb75361c5b4cfa799b75741e",
+          "url": "https://github.com/Gowee/traceroute-map-panel"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -5539,8 +5539,13 @@
         },
         {
           "version": "0.3.0",
-          "commit": "277af7e5e38c8669eb75361c5b4cfa799b75741e",
-          "url": "https://github.com/Gowee/traceroute-map-panel"
+          "url": "https://github.com/Gowee/traceroute-map-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/Gowee/traceroute-map-panel/releases/download/v0.3.0-3/dist-v0.3.0-3.zip",
+              "md5": "ad55c08fd0b6248f0c6a0f923c69dc8b"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
Hello.

The Traceroute Map Panel has been upgraded to v0.3.0. The release is meant for fixing the incompatibility with recent Grafana versions, with some new features.

I have read the guidelines and validated the plugin with the online plugin-validator.

Release commit: https://github.com/Gowee/traceroute-map-panel/tree/277af7e5e38c8669eb75361c5b4cfa799b75741e

Demo: https://trmp-demo.bamboo.workers.dev/dashboard/snapshot/3SLNKMcx5uzx2qUssgw3EJ9a0vdg365Z (it does take a while to load due to GeoIP resolution).