### PR TITLE
Updated flaminggoat-maptrack3d-panel to v0.1.9

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -5610,13 +5610,13 @@
       "url": "https://github.com/flaminggoat/map-track-3-d",
       "versions": [
         {
-          "version": "0.1.8",
-          "commit": "53c6efb110970ec59e0883978ad95f96a3f46fd1",
+          "version": "0.1.9",
+          "commit": "05188cf25518863cd2e4475d49c3a32ec947e40e",
           "url": "https://github.com/flaminggoat/map-track-3-d",
           "download": {
             "any": {
-              "url": "https://github.com/flaminggoat/map-track-3-d/releases/download/v0.1.8/flaminggoat-maptrack3d-panel-0.1.8.zip",
-              "md5": "11edc5c807e71a0fdde8bfee7b98e837"
+              "url": "https://github.com/flaminggoat/map-track-3-d/releases/download/v0.1.9/flaminggoat-maptrack3d-panel-0.1.9.zip",
+              "md5": "8ede19b69a39cffadb025ebab5cea0e9"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -5619,6 +5619,17 @@
               "md5": "8ede19b69a39cffadb025ebab5cea0e9"
             }
           }
+        },
+        {
+          "version": "0.1.8",
+          "commit": "53c6efb110970ec59e0883978ad95f96a3f46fd1",
+          "url": "https://github.com/flaminggoat/map-track-3-d",
+          "download": {
+            "any": {
+              "url": "https://github.com/flaminggoat/map-track-3-d/releases/download/v0.1.8/flaminggoat-maptrack3d-panel-0.1.8.zip",
+              "md5": "11edc5c807e71a0fdde8bfee7b98e837"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
Fixes an issue where latitude/longitude points were not aligned with globe texture.

Sorry for opening PR so soon after getting the first version published.