### PR TITLE
Add TencentCloud Monitor Grafana App Plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1,6 +1,34 @@
 {
   "plugins": [
     {
+      "id": "tencentcloud-monitor-app",
+      "type": "app",
+      "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+      "versions": [
+        {
+          "version": "2.0.0",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.0.0/tencentcloud-monitor-app-2.0.0.zip",
+              "md5": "2f9cfb5e7c9aa8219b2a12f3b82ada90"
+            }
+          }
+        },
+        {
+          "version": "2.0.1",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.0.1/tencentcloud-monitor-app-2.0.1.zip",
+              "md5": "e8aa900b6565b4d3b5cbdc6f5a806a4f"
+            }
+          }
+        }
+        
+      ]
+    },
+    {
       "id": "sskgo-perfcurve-panel",
       "type": "panel",
       "url": "https://github.com/SSKGo/perfcurve-panel",


### PR DESCRIPTION
Hi @marcusolsson, on behalf of [Tencent Cloud](https://intl.cloud.tencent.com/), we would like to add our `TencentCloud Monitor Grafana App` to Grafana Plugins. (plugin id: `tencentcloud-monitor-app`)

Please note that the previous [Pull Request](https://github.com/grafana/grafana-plugin-repository/pull/430) is now deprecated and you are free to close in anytime.

The SecretKey/SecretId credentials for Grafana testing this plugin will send to you via email.

Please let me know if you have any comments and we may change it.

Thank you,
James Wang @ Tencent Cloud