### PR TITLE
Update gapit-htmlgraphics-panel v1.3.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -5822,6 +5822,17 @@
               "md5": "2e650d2ced1a4811f0f030474e9b68b5"
             }
           }
+        },
+        {
+          "version": "1.3.2",
+          "commit": "8aab763e7fd082c51cd8fcefe8725c4d9b5652b6",
+          "url": "https://github.com/gapitio/gapit-htmlgraphics-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/gapitio/gapit-htmlgraphics-panel/releases/download/v1.3.2/gapit-htmlgraphics-panel-1.3.2.zip",
+              "md5": "4a889703fb169c8573a845685413bcf5"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -5824,13 +5824,13 @@
           }
         },
         {
-          "version": "1.3.2",
-          "commit": "8aab763e7fd082c51cd8fcefe8725c4d9b5652b6",
+          "version": "1.3.3",
+          "commit": "2fbebf5003755b13723fa64bc45ec561443c7ed2",
           "url": "https://github.com/gapitio/gapit-htmlgraphics-panel",
           "download": {
             "any": {
-              "url": "https://github.com/gapitio/gapit-htmlgraphics-panel/releases/download/v1.3.2/gapit-htmlgraphics-panel-1.3.2.zip",
-              "md5": "4a889703fb169c8573a845685413bcf5"
+              "url": "https://github.com/gapitio/gapit-htmlgraphics-panel/releases/download/v1.3.3/gapit-htmlgraphics-panel-1.3.3.zip",
+              "md5": "85dd52c31adc6a70690e78a910d52fdb"
             }
           }
         }


### PR DESCRIPTION
## v1.3.3 (2021-04-12)

### Bug fixes

- **Repo**: Fix errors not logged in the console [#22](https://github.com/gapitio/gapit-htmlgraphics-panel/pull/22)

## v1.3.2 (2021-04-07)

### Bug fixes

- **Repo**: Fix editor not loading with sub path [#20](https://github.com/gapitio/gapit-htmlgraphics-panel/pull/20)