### PR TITLE
Update tencentcloud-monitor-app to 2.0.2

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1,6 +1,34 @@
 {
   "plugins": [
     {
+      "id": "tencentcloud-monitor-app",
+      "type": "app",
+      "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+      "versions": [
+        {
+          "version": "2.0.0",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.0.0/tencentcloud-monitor-app-2.0.0.zip",
+              "md5": "2f9cfb5e7c9aa8219b2a12f3b82ada90"
+            }
+          }
+        },
+        {
+          "version": "2.0.1",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.0.1/tencentcloud-monitor-app-2.0.1.zip",
+              "md5": "e8aa900b6565b4d3b5cbdc6f5a806a4f"
+            }
+          }
+        }
+        
+      ]
+    },
+    {
       "id": "sskgo-perfcurve-panel",
       "type": "panel",
       "url": "https://github.com/SSKGo/perfcurve-panel",

--- a/repo.json
+++ b/repo.json
@@ -24,6 +24,16 @@
               "md5": "e8aa900b6565b4d3b5cbdc6f5a806a4f"
             }
           }
+        },
+        {
+          "version": "2.0.2",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.0.2/tencentcloud-monitor-app-2.0.2.zip",
+              "md5": "930e2d16f0ac9d703b12cfc7a0172ee3"
+            }
+          }
         }
         
       ]


### PR DESCRIPTION
Hi, we would like to update a patch version to 2.0.2.

See [Changelog](https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/tag/2.0.2) and [File Changes](https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/compare/release/2.0.1...release/2.0.2).

Thanks.