### PR TITLE
Update macropower-analytics-panel to 2.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4625,6 +4625,17 @@
           "version": "1.1.1",
           "commit": "fb38ba704e582b2cefd3d2efea837ca9fc865af3",
           "url": "https://github.com/MacroPower/macropower-analytics-panel"
+        },
+        {
+          "version": "2.0.0",
+          "commit": "1fbc2f9191cdcb2e002b42af64347ccd244684f9",
+          "url": "https://github.com/MacroPower/macropower-analytics-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/MacroPower/macropower-analytics-panel/releases/download/v2.0.0/macropower-analytics-panel-2.0.0.zip",
+              "md5": "1fba4f9f0c09a6f84c610626c86a221b"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
This release is a near complete rewrite of the plugin, I expect that it will break at least a few implementations in place for 1.x.x.

Changes:
- Panel is now stateless, sessions are matched using a UUID, not a database ID.
- Panel now optionally forwards heartbeats, which can be used to accurately report session duration.
- New payload schema, now including variables & focused state.
- Updates and cleans up plugin dependencies.
- Adds a verified signature.
- Adds an included [backend server](https://github.com/MacroPower/macropower-analytics-panel/tree/master/server).
- Adds better examples, docs, descriptions, etc.

If you would like to test things out, I have compose files for a Grafana + Prometheus + macropower-analytics-panel (w/ server) stack with included dashboards and such. Just clone, checkout the release/v2.0.0 branch (has the dist), and run:

```
docker-compose -f example/server/docker-compose.yaml up
```