### PR TITLE
ClickHouse Database datasource plugin update to 2.3.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -2324,6 +2324,17 @@
               "md5": "bcebceb6f248194b6cc51fec118bd425"
             }
           }
+        },
+        {
+          "version": "2.3.1",
+          "commit": "7449aac7ad992aefb733f36ba13f4343c699ecc2",
+          "url": "https://github.com/Vertamedia/clickhouse-grafana",
+          "download": {
+            "any": {
+              "url": "https://github.com/Vertamedia/clickhouse-grafana/releases/download/v2.3.1/vertamedia-clickhouse-datasource-2.3.1.zip",
+              "md5": "cfef9af53b1ca05fa89efe00c1a7e1a8"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
# 2.3.1 (2021-04-23)
## Breaking changes

* On latest Grafana 7.x releases, template variables SQL queries shall return only scalar types of values, see https://github.com/Vertamedia/clickhouse-grafana/issues/328

## Enhancement:

* add support Apple M1 ;)
* switch to new grafana plugin Golang SDK, thanks to @bmanth60 and @valeriakononenko for help
* add BasicAuth support for alerts, see https://github.com/Vertamedia/clickhouse-grafana/issues/267

## Fixes:

* fix github actions backend build
* fix UNION ALL parsing, see https://github.com/Vertamedia/clickhouse-grafana/issues/319
* fix many issues with alerting
  * https://github.com/Vertamedia/clickhouse-grafana/issues/305
  * https://github.com/Vertamedia/clickhouse-grafana/issues/327
  * https://github.com/Vertamedia/clickhouse-grafana/issues/334
  * https://github.com/Vertamedia/clickhouse-grafana/issues/335

Signed-off-by: Eugene Klimov <eklimov@altinity.com>