### PR TITLE
Add Redis Explorer plug-in

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -35,7 +35,6 @@
             }
           }
         }
-
       ]
     },
     {
@@ -6065,6 +6064,24 @@
             "any": {
               "url": "https://github.com/rajsameer/vertica-datasource/releases/download/v1.0.5/rajsameer-vertica-datasource-1.0.5.zip",
               "md5": "61e022b9bf6f2afb2311f983be4a53cb"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "redis-explorer-app",
+      "type": "app",
+      "url": "https://github.com/RedisGrafana/grafana-redis-explorer",
+      "versions": [
+        {
+          "version": "1.1.0",
+          "commit": "df4766e23c4455b4858e64223d10532a8e8b8560",
+          "url": "https://github.com/RedisGrafana/grafana-redis-explorer",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-explorer/releases/download/v1.1.0/redis-explorer-app-1.1.0.zip",
+              "md5": "511422fc8d50e06c1308dae99d065802"
             }
           }
         }


### PR DESCRIPTION
@marcusolsson @briangann Please review and add a new commercial plug-in Redis Explorer.

To verify:
1. Start Redis Enterprise
```
docker-compose up redis
```
2. Create a new cluster following: https://docs.redislabs.com/latest/rs/administering/new-cluster-setup/
3. Build and start Grafana following https://redisgrafana.github.io/development/redis-explorer/
```
yarn install
yarn build
yarn start:dev
```
4. Add Redis Enterprise Software Data Source following https://redisgrafana.github.io/redis-explorer/re-software/overview/

Please let me know if you have any questions.

![Screen Shot 2021-04-29 at 5 25 13 PM](https://user-images.githubusercontent.com/47795110/116622715-21b64c00-a913-11eb-816b-5d1595894024.png)
