### PR TITLE
Update frser-sqlite-datasource to v2.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -35,7 +35,6 @@
             }
           }
         }
-
       ]
     },
     {
@@ -2940,6 +2939,16 @@
             "any": {
               "url": "https://github.com/fr-ser/grafana-sqlite-datasource/releases/download/v1.2.0/frser-sqlite-datasource-1.2.0.zip",
               "md5": "c078be8a503f81237c83b93299773c9d"
+            }
+          }
+        },
+        {
+          "version": "2.0.0",
+          "url": "https://github.com/fr-ser/grafana-sqlite-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/fr-ser/grafana-sqlite-datasource/releases/download/v2.0.0/frser-sqlite-datasource-2.0.0.zip",
+              "md5": "e7ea9f43d8ba3400e194338c540ec4b1"
             }
           }
         }


### PR DESCRIPTION
Same Code but changed the default 32bit ARM version from 7 to 6.
See changelog: https://github.com/fr-ser/grafana-sqlite-datasource/blob/master/CHANGELOG.md