### PR TITLE
Update Redis Data Source 1.4.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -45,7 +45,6 @@
             }
           }
         }
-
       ]
     },
     {
@@ -5654,6 +5653,17 @@
             "any": {
               "url": "https://github.com/RedisGrafana/grafana-redis-datasource/releases/download/v1.3.1/redis-datasource-1.3.1.zip",
               "md5": "7a36a13966c11cf12316422361376cc0"
+            }
+          }
+        },
+        {
+          "version": "1.4.0",
+          "commit": "ed63cae45ec81eaf8929d65ae2a7f25a299ee58c",
+          "url": "https://github.com/RedisGrafana/grafana-redis-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-datasource/releases/download/v1.4.0/redis-datasource-1.4.0.zip",
+              "md5": "ac25cebeea24806123adea98fdf64892"
             }
           }
         }


### PR DESCRIPTION
@marcusolsson @briangann Please review and add a new version of Redis Data Source 1.4.0.

To start docker-compose with test database please run: `npm run start:dev`

### Features / Enhancements

- Update Grafana SDK 0.88 and other backend dependencies (#170)
- Add $time field for Streams XRANGE (#175)
- Add RG.PYDUMPREQS command and integration test fix (#183)
- Add Integration tests to CI (#184)
- Upgrade Grafana dependencies to 7.5.4 (#185)
- Update Dashboard to 7.5.4 and add data source variable (#186)
- Update backend dependencies and linting issues (#187)
- Update Documentation (#188)

### Bug fixes

- TLS client certificates not working (#177)

![Screen Shot 2021-05-10 at 10 53 28 AM](https://user-images.githubusercontent.com/47795110/117679964-ba07c880-b17e-11eb-8df9-ceaee7314474.png)
