### PR TITLE
OpenNMS Helm 7.1.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -763,12 +763,12 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
-          "version": "7.1.0",
+          "version": "7.1.2",
           "url": "https://github.com/OpenNMS/opennms-helm",
 	  "download": {
              "any": {
-               "url": "https://github.com/OpenNMS/opennms-helm/releases/download/v7.1.0/opennms-helm-app-7.1.0.zip",
-               "md5": "2282a6f9362fb90d3a61295f60c8d31a"
+               "url": "https://github.com/OpenNMS/opennms-helm/releases/download/v7.1.2/opennms-helm-app-7.1.2.zip",
+               "md5": "8f33cdc23a32136918443c62701a1e76"
              }
 	  }
         },

--- a/repo.json
+++ b/repo.json
@@ -763,6 +763,11 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
+          "version": "7.0.0",
+          "commit": "b475d03da94d1eadb4361ec8f7c7868eec43dfff",
+          "url": "https://github.com/OpenNMS/opennms-helm"
+        },
+        {
           "version": "6.0.0",
           "commit": "c93251b9ed0c344452be281b9a95c1fb1bf78ec6",
           "url": "https://github.com/OpenNMS/opennms-helm"

--- a/repo.json
+++ b/repo.json
@@ -763,9 +763,14 @@
       "url": "https://github.com/OpenNMS/opennms-helm",
       "versions": [
         {
-          "version": "7.0.0",
-          "commit": "b475d03da94d1eadb4361ec8f7c7868eec43dfff",
-          "url": "https://github.com/OpenNMS/opennms-helm"
+          "version": "7.1.0",
+          "url": "https://github.com/OpenNMS/opennms-helm",
+	  "download": {
+             "any": {
+               "url": "https://github.com/OpenNMS/opennms-helm/releases/download/v7.1.0/opennms-helm-app-7.1.0.zip",
+               "md5": "2282a6f9362fb90d3a61295f60c8d31a"
+             }
+	  }
         },
         {
           "version": "6.0.0",


### PR DESCRIPTION
This release contains a rework of our code to use TypeScript, and a conversion to Grafana's
build toolkit for releasing.  This should fix a number of transient issues we've seen in
startup of the Helm plugin and increase overall stability.

BREAKING: OpenNMS Helm now requires Grafana 7.5 or greater.

I have a demo environment you can point to, but obviously don't want to post passwords in public, ping me out-of-band for it if I don't find you first.