### PR TITLE
Zabbix plugin 4.1.5

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -265,6 +265,17 @@
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
         {
+          "version": "4.1.5",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix",
+          "commit": "54d46f81bb635d45fb182bc751ea994e7ea85cee",
+          "download": {
+            "any": {
+              "url": "https://github.com/alexanderzobnin/grafana-zabbix/releases/download/v4.1.5/alexanderzobnin-zabbix-app-4.1.5.zip",
+              "md5": "87f7bf416e320877833cd070f56c71ce"
+            }
+          }
+        },
+        {
           "version": "4.1.4",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix",
           "commit": "e77990f9413bae4c7b5b9124c6154dec9d6af811",


### PR DESCRIPTION
Compatibility fix for Zabbix 5.4

## [4.1.5] - 2021-05-18
### Fixed
- Fix compatibility with Zabbix 5.4, [#1188](https://github.com/alexanderzobnin/grafana-zabbix/issues/1188)