### PR TITLE
Add Pixie datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6342,6 +6342,23 @@
           }
         }
       ]
+    },
+    {
+      "id": "pixie-pixie-datasource",
+      "type": "datasource",
+      "url": "https://github.com/pixie-labs/grafana-plugin",
+      "versions": [
+        {
+          "version": "0.0.1",
+          "url": "https://github.com/pixie-labs/grafana-plugin",
+          "download": {
+            "any": {
+              "url": "https://github.com/pixie-labs/grafana-plugin/releases/download/untagged-5076e6c8808ec901844f/pixie-pixie-datasource-0.0.1.zip",
+              "md5": "d4226fea6257812b0a445854d4107ee0"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This adds the Pixie datasource plugin. Pixie's repo can be found here: https://github.com/pixie-labs/pixie. The plugin repo is at https://github.com/pixie-labs/grafana-plugin 