### PR TITLE
Adds pyroscope panel and datasource plugins

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6484,12 +6484,12 @@
       "versions": [
         {
           "version": "1.0.0",
-          "commit": "a8e6b9e577a64fb712a0cb129ac472d1c53cead9",
+          "commit": "d05ea18ed3cc5ba518052ea7258c324b85b5a9d6",
           "url": "https://github.com/pyroscope-io/grafana-panel-plugin",
           "download": {
             "any": {
               "url": "https://github.com/pyroscope-io/grafana-panel-plugin/releases/download/v1.0.0/pyroscope-panel-1.0.0.zip",
-              "md5": "27a33b0bb59dea40d20ccdf654d92148"
+              "md5": "f986fbfc5189602b844b4fffc79272b4"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -3903,7 +3903,7 @@
               "md5": "e3858295a0cc0fb1be76cf0ba34474bf"
             }
           }
-        }        
+        }
       ]
     },
     {
@@ -6422,6 +6422,42 @@
             "any": {
               "url": "https://github.com/bmcsoftware/bmchelix-datasource/releases/download/v1.0.1/bmchelix-ade-datasource-V1.0.1.zip",
               "md5": "b14861008657f496fe8135977174667d"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "pyroscope-panel",
+      "type": "panel",
+      "url": "https://github.com/pyroscope-io/grafana-panel-plugin",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "a8e6b9e577a64fb712a0cb129ac472d1c53cead9",
+          "url": "https://github.com/pyroscope-io/grafana-panel-plugin",
+          "download": {
+            "any": {
+              "url": "https://github.com/pyroscope-io/grafana-panel-plugin/releases/download/v1.0.0/pyroscope-panel-1.0.0.zip",
+              "md5": "27a33b0bb59dea40d20ccdf654d92148"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "pyroscope-datasource",
+      "type": "datasource",
+      "url": "https://github.com/pyroscope-io/grafana-datasource-plugin",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "d6abc84d7a7a0cfd4450ed91827f11af93bfc035",
+          "url": "https://github.com/pyroscope-io/grafana-datasource-plugin",
+          "download": {
+            "any": {
+              "url": "https://github.com/pyroscope-io/grafana-datasource-plugin/releases/download/v1.0.0/pyroscope-datasource-1.0.0.zip",
+              "md5": "f40ad1683a1261f93206c76d730388ad"
             }
           }
         }


### PR DESCRIPTION
Hi Grafana team!

This PR adds [pyroscope](https://github.com/pyroscope-io/pyroscope/) panel and datasource plugins.

To test the datasource plugin you can run `docker run -it -p 4040:4040 pyroscope/pyroscope:latest server` and use localhost:4040 as the address in datasource config. For app name you can use `pyroscope.server.cpu` and that be pyroscope profiling itself. We also have a publicly available server at https://demo.pyroscope.io/ .

We also have a live demo deployed at [grafana-demo.pyroscope.io](https://grafana-demo.pyroscope.io/d/9_aiZ46Gz/pyroscope-plugins?orgId=1)

Both plugins are currently not signed, I'll update this PR once we get our grafana account approved. The name of the Grafana Cloud org is `pyroscopedmitry`.
