### PR TITLE
Adds teamviewer datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6599,6 +6599,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "teamviewer-datasource",
+      "type": "datasource",
+      "url": "https://github.com/teamviewer/grafana-teamviewer-datasource",
+      "versions": [
+        {
+          "version": "1.0.1",
+          "commit": "baa247b65a1ef87486dc9c5dd5d8ac81d8ea679e",
+          "url": "https://github.com/teamviewer/grafana-teamviewer-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/teamviewer/grafana-teamviewer-datasource/releases/download/v1.0.1/teamviewer-datasource-1.0.1.zip",
+              "md5": "d253acb797fa35ca4a0763d70621af37"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hi Grafana Team,

This adds the [TeamViewer Datasource Plugin](https://github.com/teamviewer/grafana-teamviewer-datasource).
For testing purposes, you can create your own account [here](https://www.teamviewer.com/en/remote-management/web-monitoring/) or contact us as this is a commercial plugin, and we will provide you an account.