### PR TITLE
Add Base64 Image/PDF panel 1.0.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6476,6 +6476,22 @@
           }
         }
       ]
+      "id": "volkovlabs-image-panel",
+      "type": "panel",
+      "url": "https://github.com/VolkovLabs/grafana-image-panel",
+      "versions": [
+        {
+          "version": "1.0.1",
+          "commit": "7627e552c46dcd0710f0408ba993f5257be0587e",
+          "url": "https://github.com/VolkovLabs/grafana-image-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/VolkovLabs/grafana-image-panel/releases/download/v1.0.1/volkovlabs-image-panel-1.0.1.zip",
+              "md5": "c9770dbc434bf4cc1e7d2134dfc99b1a"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -6476,6 +6476,8 @@
           }
         }
       ]
+    },
+    {
       "id": "volkovlabs-image-panel",
       "type": "panel",
       "url": "https://github.com/VolkovLabs/grafana-image-panel",


### PR DESCRIPTION
@marcusolsson Please review and add a Base64 Image/PDF panel 1.0.1, which can display base64 encoded images from the data source.

To start please run `npm run start` to start Grafana with Marcus's Static data source.

## Features / Enhancements

- Initial release based on Grafana 7.5.7
- Supports PNG, JPG, GIF, and PDF
- Add screenshots for Static and Redis data sources

![Screen Shot 2021-06-07 at 10 33 44 PM](https://user-images.githubusercontent.com/47795110/121114523-d3ce1700-c7e1-11eb-900c-5823b6245247.png)
