### PR TITLE
Adding v1.1.1 of the OPC UA plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6489,7 +6489,7 @@
             "any": {
               "url": "https://github.com/srclosson/opcua-datasource/releases/download/v1.1.1/opcua-datasource-1.1.1.zip",
               "md5": "cea44c88675eb41dbaf92e092fdbf654"
-            }
+            } 
           }
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -6483,13 +6483,13 @@
       "url": "https://github.com/srclosson/opcua-datasource/",
       "versions": [
         {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "url": "https://github.com/srclosson/opcua-datasource/",
           "download": {
             "any": {
-              "url": "https://github.com/srclosson/opcua-datasource/releases/download/v1.1.1/opcua-datasource-1.1.1.zip",
-              "md5": "cea44c88675eb41dbaf92e092fdbf654"
-            } 
+              "url": "https://github.com/srclosson/opcua-datasource/releases/download/v1.1.2/opcua-datasource-1.1.2.zip",
+              "md5": "670f01df51f02ff2c66e6a6bb81c2fee"
+            }
           }
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -6448,7 +6448,7 @@
         }
       ]
     },
-        {
+    {
       "id": "bmchelix-ade-datasource",
       "type": "datasource",
       "url": "https://github.com/bmcsoftware/bmchelix-datasource",

--- a/repo.json
+++ b/repo.json
@@ -6476,6 +6476,23 @@
           }
         }
       ]
+    },
+    {
+      "id": "opcua-datasource",
+      "type": "datasource",
+      "url": "https://github.com/srclosson/opcua-datasource/",
+      "versions": [
+        {
+          "version": "1.1.1",
+          "url": "https://github.com/srclosson/opcua-datasource/",
+          "download": {
+            "any": {
+              "url": "https://github.com/srclosson/opcua-datasource/releases/download/v1.1.1/opcua-datasource-1.1.1.zip",
+              "md5": "cea44c88675eb41dbaf92e092fdbf654"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
The OPC UA datasource allows you to connect to an OPC UA server. The plugin is public and needs to be signed after the initial vetting process. Documentation is provided in the README.md file. A demo public test OPC UA Server running at opc.tcp://opcua.prediktor.com:4880