### PR TITLE
OPC UA Datasource Plugin v1.1.2

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6489,7 +6489,7 @@
             "any": {
               "url": "https://github.com/srclosson/opcua-datasource/releases/download/v1.1.1/opcua-datasource-1.1.1.zip",
               "md5": "cea44c88675eb41dbaf92e092fdbf654"
-            }
+            } 
           }
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -6483,13 +6483,13 @@
       "url": "https://github.com/srclosson/opcua-datasource/",
       "versions": [
         {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "url": "https://github.com/srclosson/opcua-datasource/",
           "download": {
             "any": {
-              "url": "https://github.com/srclosson/opcua-datasource/releases/download/v1.1.1/opcua-datasource-1.1.1.zip",
-              "md5": "cea44c88675eb41dbaf92e092fdbf654"
-            } 
+              "url": "https://github.com/srclosson/opcua-datasource/releases/download/v1.1.2/opcua-datasource-1.1.2.zip",
+              "md5": "670f01df51f02ff2c66e6a6bb81c2fee"
+            }
           }
         }
       ]

--- a/repo.json
+++ b/repo.json
@@ -6448,7 +6448,7 @@
         }
       ]
     },
-        {
+    {
       "id": "bmchelix-ade-datasource",
       "type": "datasource",
       "url": "https://github.com/bmcsoftware/bmchelix-datasource",

--- a/repo.json
+++ b/repo.json
@@ -6476,6 +6476,23 @@
           }
         }
       ]
+    },
+    {
+      "id": "opcua-datasource",
+      "type": "datasource",
+      "url": "https://github.com/srclosson/opcua-datasource/",
+      "versions": [
+        {
+          "version": "1.1.1",
+          "url": "https://github.com/srclosson/opcua-datasource/",
+          "download": {
+            "any": {
+              "url": "https://github.com/srclosson/opcua-datasource/releases/download/v1.1.1/opcua-datasource-1.1.1.zip",
+              "md5": "cea44c88675eb41dbaf92e092fdbf654"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -4675,6 +4675,25 @@
               "md5": "94a250196fd0e13b734334c2c46e114f"
             }
           }
+        },
+        {
+          "version": "3.0.0",
+          "commit": "8491418fe53090abde5f59ad0ca3413f91e798d5",
+          "url": "https://github.com/grafana/grafana-image-renderer",
+          "download": {
+            "darwin-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v3.0.0/plugin-darwin-x64-unknown.zip",
+              "md5": "f111ef722eca2c2a27486744bb4ce162"
+            },
+            "linux-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v3.0.0/plugin-linux-x64-glibc.zip",
+              "md5": "4931eb9df50113d492e3e1507a780f13"
+            },
+            "windows-amd64": {
+              "url": "https://github.com/grafana/grafana-image-renderer/releases/download/v3.0.0/plugin-win32-x64-unknown.zip",
+              "md5": "2171f542ab951d19de6f8e0f19ea34a0"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
This datasource plugin allows Grafana to get data directly from one or more OPC UA Servers. Documentation in the plugin, also on connecting to a demo server