### PR TITLE
add simple-grpc-datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6515,18 +6515,18 @@
       ]
     },
     {
-      "id": "simple-grpc-datasource",
+      "id": "innius-simple-grpc-datasource",
       "type": "datasource",
       "url": "https://github.com/innius/grafana-simple-grpc-datasource",
       "versions": [
         {
-          "version": "1.0.0",
-          "commit": "38ad70be0d211e63cea65a7806c42cfe26ca98ca",
+          "version": "1.0.1",
+          "commit": "ee33ac718d9d194abab13fa3204b63e6074fc5c3",
           "url": "https://github.com/innius/grafana-simple-grpc-datasource",
           "download": {
             "any": {
-              "url": "https://github.com/innius/grafana-simple-grpc-datasource/releases/download/v1.0.0/simple-grpc-datasource-1.0.0.zip",
-              "md5": "fa0e8d995011f039a6ac4547f1849bf6"
+              "url": "https://github.com/innius/grafana-simple-grpc-datasource/releases/download/v1.0.1/innius-simple-grpc-datasource-1.0.1.zip",
+              "md5": "c4aafc0f1368fd3f360c8e024c23b370"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -6513,6 +6513,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "simple-grpc-datasource",
+      "type": "datasource",
+      "url": "https://github.com/innius/grafana-simple-grpc-datasource",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "38ad70be0d211e63cea65a7806c42cfe26ca98ca",
+          "url": "https://github.com/innius/grafana-simple-grpc-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/innius/grafana-simple-grpc-datasource/releases/download/v1.0.0/simple-grpc-datasource-1.0.0.zip",
+              "md5": "fa0e8d995011f039a6ac4547f1849bf6"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -6515,22 +6515,22 @@
       ]
     },
     {
-      "id": "innius-simple-grpc-datasource",
+      "id": "innius-grpc-datasource",
       "type": "datasource",
       "url": "https://github.com/innius/grafana-simple-grpc-datasource",
       "versions": [
         {
-          "version": "1.0.1",
-          "commit": "ee33ac718d9d194abab13fa3204b63e6074fc5c3",
+          "version": "1.0.2",
+          "commit": "8de81e04eb27c2460e2c3337b0ad56d52252690d",
           "url": "https://github.com/innius/grafana-simple-grpc-datasource",
           "download": {
             "any": {
-              "url": "https://github.com/innius/grafana-simple-grpc-datasource/releases/download/v1.0.1/innius-simple-grpc-datasource-1.0.1.zip",
-              "md5": "c4aafc0f1368fd3f360c8e024c23b370"
+              "url": "https://github.com/innius/grafana-simple-grpc-datasource/releases/download/v1.0.2/innius-grpc-datasource-1.0.2.zip",
+              "md5": "1fdfb86c320b1abdb261d1d5389aa158"
             }
           }
         }
       ]
-    }
+    }    
   ]
 }


### PR DESCRIPTION
Hi, 

I've made a new datasource plugin for grafana. This datasource can connect to any backend which has implemented the grpc interface of the plugin. This makes it possible to connect legacy systems to grafana. 

More details can be found in the README of the [repository](https://github.com/innius/grafana-simple-grpc-datasource).


Regards,
Ron
