### PR TITLE
Anodot Datasource 1.0.2

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6400,6 +6400,16 @@
               "md5": "dabfe80110c22ee7ae781273798eb92f"
             }
           }
+        },
+        {
+          "version": "1.0.2",
+          "url": "https://github.com/anodot/grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/anodot/grafana-datasource/raw/main/anodot-datasource-1.0.2.zip",
+              "md5": "b956db345daafabc616e9299c562fcc7"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6047,7 +6047,7 @@
     },
     {
       "id": "anodot-datasource",
-      "type": "panel",
+      "type": "datasource",
       "url": "https://github.com/anodot/grafana-datasource",
       "versions": [
         {

--- a/repo.json
+++ b/repo.json
@@ -6032,6 +6032,16 @@
               "md5": "cdee4b59d3967d02b3124ce1ace56157"
             }
           }
+        },
+        {
+          "version": "1.0.1",
+          "url": "https://github.com/anodot/grafana-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/anodot/grafana-panel/raw/main/anodot-panel-1.0.1.zip",
+              "md5": "f5add742c5f760b7e5ed767479e7f7c6"
+            }
+          }
         }
       ]
     },
@@ -6047,6 +6057,16 @@
             "any": {
               "url": "https://github.com/anodot/grafana-datasource/raw/main/anodot-datasource-1.0.0.zip",
               "md5": "13056917de9a0e9af570079cbef33316"
+            }
+          }
+        },
+        {
+          "version": "1.0.1",
+          "url": "https://github.com/anodot/grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/anodot/grafana-datasource/raw/main/anodot-datasource-1.0.1.zip",
+              "md5": "dabfe80110c22ee7ae781273798eb92f"
             }
           }
         }


### PR DESCRIPTION
As we don't store API token on the backend and it is stored on fronend localStorage instead, if multiple users use Grafana server, only those of them have API token stored who manually pressed buttot "Save and test" in datasource settings. This patch adds automatic requests of API token for all users of Grafana instance if right credentials were set before.