### PR TITLE
Update VolkovLabs Image Panel 2.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6597,6 +6597,17 @@
               "md5": "c9770dbc434bf4cc1e7d2134dfc99b1a"
             }
           }
+        },
+        {
+          "version": "2.0.0",
+          "commit": "694523b8fbda3500e3110bb37bbfef6bd0a693b5",
+          "url": "https://github.com/VolkovLabs/grafana-image-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/VolkovLabs/grafana-image-panel/releases/download/v2.0.0/volkovlabs-image-panel-2.0.0.zip",
+              "md5": "25fa95780b68370aefa5fe2c4612ffcb"
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
@marcusolsson Please review and update a Base64 Image/PDF panel 2.0.0 based on Grafana 8.

To start please run `npm run start` to start Grafana with Marcus's Static data source.

## 2.0.0 (2021-06-19)

### Breaking changes

- Supports Grafana 8.0+, for Grafana 7.X use version 1.0.1 or 1.1.0

### Features / Enhancements

- Based on Grafana 8.0.2

## 1.1.0 (2021-06-19)

### Features / Enhancements

- Display base64 image with header #7 (Display base64 Image from InfluxDB #6)
- Increase tests coverage #4

![Screen Shot 2021-06-19 at 3 29 33 PM](https://user-images.githubusercontent.com/47795110/122653595-98054c80-d113-11eb-8ed3-2e0a0122e5a2.png)
