### PR TITLE
Upgrade Matomo Tracker panel to 0.2.3

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -4964,6 +4964,11 @@
           "version": "0.2.2",
           "commit": "1b334b8b0bd3b07909623dbdbdf560d969be0328",
           "url": "https://github.com/thiagoarrais/grafana-matomo-tracking-panel"
+        },
+        {
+          "version": "0.2.3",
+          "commit": "2fc7824192673e57d4e13e7b9cff57fab2490c33",
+          "url": "https://github.com/thiagoarrais/grafana-matomo-tracking-panel"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -4968,7 +4968,13 @@
         {
           "version": "0.2.3",
           "commit": "2fc7824192673e57d4e13e7b9cff57fab2490c33",
-          "url": "https://github.com/thiagoarrais/grafana-matomo-tracking-panel"
+          "url": "https://github.com/thiagoarrais/grafana-matomo-tracking-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/thiagoarrais/grafana-matomo-tracking-panel/releases/download/v0.2.3/thiagoarrais-matomotracking-panel-0.2.3.zip",
+              "md5": "bb6cf41db03a6ab7e4f36aa237a2ddb5"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
This PR publishes Matomo Tracker panel v0.2.3 to Grafana marketplace.

Version 0.2.3 does not include any new features. It mainly upgrades dependencies and adds [code signing](https://github.com/thiagoarrais/grafana-matomo-tracking-panel/issues/9).