### PR TITLE
Update Redis Application 2.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6126,6 +6126,17 @@
               "md5": "b9ef34794a5e38af5b0c40c60811e2a1"
             }
           }
+        },
+        {
+          "version": "2.0.0",
+          "commit": "3b944105fc03e3c9b8c37072dffb7605c2edd210",
+          "url": "https://github.com/RedisGrafana/grafana-redis-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-app/releases/download/v2.0.0/redis-app-2.0.0.zip",
+              "md5": "ce3cf2b50a8a9b673bbd4823183e1683"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
@briangann  Please review and add a new version of Redis Application plug-in 2.0.0.

To start docker-compose with please run: `npm run start:dev`

### Breaking changes

Supports Grafana 8.0+, for Grafana 7.X use version 1.2.0

### Features / Enhancements

- Upgrade to Grafana 8.0.2 (67)
- Update dashboards for v8 and minor updates (69)
- Replace old Latency Graph with TimeSeries component (70)
- Add Redis 7 commands to CLI (71)
- Add NgAlert and Plugin catalog to docker image (72)
- Update dashboards in the application's menu as pages (73)
- Update CLI legacy switch to ButtonGroup (74)

### Bug fixes

- "Available Requirements" panel should be set to $redis data source (63)
- Cannot read property 'v1' of undefined (theme.v1) in the Grafana 8 (65)
- Add theme to getDisplayProcessor (66)
- Fix adding new data source and minor updates (68)

![Screen Shot 2021-06-26 at 12 27 09 PM](https://user-images.githubusercontent.com/47795110/123519679-d69e8800-d67a-11eb-9f05-62859b825c2a.png)
