### PR TITLE
Update Redis Explorer 2.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6528,6 +6528,17 @@
               "md5": "511422fc8d50e06c1308dae99d065802"
             }
           }
+        },
+        {
+          "version": "2.0.0",
+          "commit": "a8bc61f858fc8f1617d0eac70339906792a45124",
+          "url": "https://github.com/RedisGrafana/grafana-redis-explorer",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-explorer/releases/download/v2.0.0/redis-explorer-app-2.0.0.zip",
+              "md5": "2a760946a6fc6be59f4f312c8a4bba31"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
@briangann Please review and add a new version of the Redis Explorer application to 2.0.0.

### Breaking changes

Supports Grafana 8.0+, for Grafana 7.X use version 1.1.0

### Features / Enhancements

- Update Readme to add official Grafana repository (52)
- Upgrade to Grafana 8.0.1 (53)
- Update dashboards and screenshots for Grafana 8 (55)
- Add NgAlert and Plugin Catalog to Docker image with minor doc updates (58)
- Update dashboards in the application's menu as pages (59)

To review:
1. Start Redis Enterprise
```
docker-compose up redis
```
2. Create a new cluster following: https://docs.redislabs.com/latest/rs/administering/new-cluster-setup/
3. Build and start Grafana following https://redisgrafana.github.io/development/redis-explorer/
```
yarn install
yarn build
yarn start:dev
```
4. Add Redis Enterprise Software Data Source following https://redisgrafana.github.io/redis-explorer/re-software/overview/

Please let me know if you have any questions.

![Screen Shot 2021-06-26 at 12 40 13 PM](https://user-images.githubusercontent.com/47795110/123519967-5711b880-d67c-11eb-8404-ed1c1fb3a20f.png)
