### PR TITLE
Update Redis Data Source 1.5.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -5968,6 +5968,17 @@
               "md5": "ac25cebeea24806123adea98fdf64892"
             }
           }
+        },
+        {
+          "version": "1.5.0",
+          "commit": "772f0c714de229535d1111cc11e64de3bc070d9f",
+          "url": "https://github.com/RedisGrafana/grafana-redis-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/RedisGrafana/grafana-redis-datasource/releases/download/v1.5.0/redis-datasource-1.5.0.zip",
+              "md5": "264f5f776d5f0cf50ea1417ffe4b1bc6"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
@briangann Please review and add a new version of Redis Data Source 1.5.0.

To start docker-compose with test database please run: `npm run start:dev`

### Breaking changes

- `HGET` returns a field with values named as a requested field instead of "Value" similar to HMGET and `HGETALL`.
- Streaming field `time` moved from Frontend to Backend. Field's name was renamed to "#time" to avoid confusion with returned fields.

### Features / Enhancements

- Add Redis Explorer to README and minor docker updates (195)
- Alerting for Grafana-Redis-Datasource (166)
- Add support for Sentinel ACL User and Password authentication separate from Redis (197)
- Add Support for RedisGraph query nodes count (199)
- Add GRAPH.EXPLAIN and GRAPH.PROFILE commands (200)
- Add GRAPH.CONFIG and RedisGraph refactoring (201)
- Refactor RedisTimeSeries and RedisGears commands (202)
- Upgrade Grafana 7.5.7 and backend dependencies (203)
- Add Streaming dashboard for v8 and update #time streaming field (204)
- Add TS.MGET command (209)
- Refactor Redis commands (210)

### Bug fixes

- Fix NaN for variables (206)

![Screen Shot 2021-07-06 at 5 37 06 PM](https://user-images.githubusercontent.com/47795110/124669886-2b16e400-de81-11eb-813e-6d9f9e040c11.png)
