### PR TITLE
Update sskgo-perfcurve-panel to v1.5.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -112,6 +112,17 @@
               "md5": "fb59cf8f264050da9e5ac42a1f8ed829"
             }
           }
+        },
+        {
+          "version": "1.5.0",
+          "commit": "f1f4047ab4e1a7566eefb2a7aab0e727c41eeb77",
+          "url": "https://github.com/SSKGo/perfcurve-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/SSKGo/perfcurve-panel/releases/download/v1.5.0/sskgo-perfcurve-panel-1.5.0.zip",
+              "md5": "17cf422fc10eef3b4788ca9d7ad53f97"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
I created this pull request because the plugin (sskgo-perfcurve-panel) raise error in Grafana v8.X.X. 
In order to solve the problem, I updated the plugin for Grafana 8.X.X and released the new version.

Please kindly accept this pull request to let people reach the new version in Grafana's official catalog.
If you have any question, please feel free to contact me.

![image](https://user-images.githubusercontent.com/54466390/125199161-d79cff80-e29f-11eb-9c90-8e11781d3fc7.png)
