### PR TITLE
Add vertica-grafana-datasource plugin

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -702,7 +702,7 @@
           "download": {
             "any": {
               "url": "https://github.com/vertica/vertica-grafana-datasource/releases/download/v2.0.0/vertica-grafana-datasource-2.0.0.zip",
-              "md5": "eff440f17920fc644b5be90e73670b49"
+              "md5": "fc59acf699889be484b56d37ca269f00"
             }
           }
         },

--- a/repo.json
+++ b/repo.json
@@ -157,8 +157,6 @@
         }
       ]
     },
-    { FOR VERTICA
-    },
     {
       "id": "aceiot-svg-panel",
       "type": "panel",
@@ -689,6 +687,18 @@
           "version": "0.0.1",
           "commit": "0edb6374cc3ab128b6b9994a9f76a8c32109fd95",
           "url": "https://github.com/srotya/sidewinder-grafana/"
+        }
+      ]
+    },
+    { 
+      "id": "vertica-grafana-datasource",
+      "type": "datasource",
+      "url": "https://github.com/vertica/vertica-grafana-datasource",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "dc4606169d1e1fb48a2d1559e82d7a776692ad6e",
+          "url": "https://github.com/vertica/vertica-grafana-datasource"
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -696,6 +696,17 @@
       "url": "https://github.com/vertica/vertica-grafana-datasource",
       "versions": [
         {
+          "version": "2.0.0",
+          "commit": "2dbe2a332b26fe97b08b0173cd8fd69c564c305c",
+          "url": "https://github.com/vertica/vertica-grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/vertica/vertica-grafana-datasource/releases/download/v2.0.0/vertica-grafana-datasource-2.0.0.zip",
+              "md5": "eff440f17920fc644b5be90e73670b49"
+            }
+          }
+        },
+        {
           "version": "1.0.0",
           "commit": "dc4606169d1e1fb48a2d1559e82d7a776692ad6e",
           "url": "https://github.com/vertica/vertica-grafana-datasource"

--- a/repo.json
+++ b/repo.json
@@ -157,6 +157,8 @@
         }
       ]
     },
+    { FOR VERTICA
+    },
     {
       "id": "aceiot-svg-panel",
       "type": "panel",


### PR DESCRIPTION
Hello Grafana team,
Vertica has created a new datasource plugin with an updated framework and SDK. This plugin allows users to query and visualize data from a Vertica database.