### PR TITLE
Add valiton-mongodbatlas-datasource

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6933,6 +6933,23 @@
           }
         }
       ]
+    },
+    {
+      "id": "valiton-mongodb-atlas-datasource",
+      "type": "datasource",
+      "url": "https://github.com/valiton/grafana-mongodb-atlas-datasource",
+      "versions": [
+        {
+          "version": "3.0.0",
+          "url": "https://github.com/valiton/grafana-mongodb-atlas-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/valiton/grafana-mongodb-atlas-datasource/releases/download/v3.0.0/valiton-mongodb-atlas-datasource.zip",
+              "md5": "a3c3d78371ddcd55ea303803e06f1437"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -6935,7 +6935,7 @@
       ]
     },
     {
-      "id": "valiton-mongodb-atlas-datasource",
+      "id": "valiton-mongodbatlas-datasource",
       "type": "datasource",
       "url": "https://github.com/valiton/grafana-mongodb-atlas-datasource",
       "versions": [


### PR DESCRIPTION
The NoSQL database MongoDB provides a Cloud version (free or commercial) with an API to check how the databases are doing. We are working here together with MongoDB Germany and decided to Open Source our plugin so that also other MongoDB users can monitor their databases. 

![Panel Example](https://github.com/valiton/grafana-mongodb-atlas-datasource/raw/master/src/img/screenshots/query_example.png)

You can run it using

```sh
docker run -p 3000:3000 \
  -e GF_INSTALL_PLUGINS="https://github.com/valiton/grafana-mongodb-atlas-datasource/releases/download/v3.0.1/valiton-mongodbatlas-datasource.zip;valiton-mongodb-atlas-datasource" \
  -e "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=valiton-mongodbatlas-datasource" \
  grafana/grafana:8.0.0
```

We can provide you with an API key so that you can test it if you don't have an own Public/Atlas Cloud access. Feel free to contact me on info@christoph-caprano.de. 

A detailed introduction on how to use this plugin can be found on our [README](https://github.com/valiton/grafana-mongodb-atlas-datasource/blob/master/README.md). 

As this is my first signed Grafana data source, I would appreciate feedback and please notify me if something is missing. 

Thank you! :-) 