### PR TITLE
add mtanda-aws-athena-datasource v2.2.7

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6939,6 +6939,23 @@
           }
         }
       ]
+    },
+    {
+      "id": "mtanda-aws-athena-datasource",
+      "type": "datasource",
+      "url": "https://github.com/mtanda/grafana-aws-athena-datasource",
+      "versions": [
+        {
+          "version": "2.2.7",
+          "url": "https://github.com/mtanda/grafana-aws-athena-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/mtanda/grafana-aws-athena-datasource/releases/download/2.2.7/grafana-aws-athena-datasource-2.2.7.zip",
+              "md5": "503e7e995aa512e0206e1496ef2d23f3"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This is based on #667 to add mtanda-aws-athena-datasource with the new requirements. Credits goes to @mtanda 

Note that as seen on the plugin's issue tracker, there's already a good amount of interest in this, and it's a pain that it's not signed yet(mtanda/grafana-aws-athena-datasource#48). On PR #667 it was mentioned that there's some doubt on whether a plugin for an AWS datasource should be added or not, but since last year AWS or anyone else hasn't released any plugin on the store, so it's about time.