### PR TITLE
Instana datasource plugin 3.3.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3346,6 +3346,17 @@
               "md5": "4ac7c80f149f0a492657f4aa8d7a2130"
             }
           }
+        },
+        {
+          "version": "3.3.1",
+          "commit": "d3647bb4ade4c0617b480164aeb60c95ff9052af",
+          "url": "https://github.com/instana/instana-grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/instana/instana-grafana-datasource/releases/download/v3.3.1/instana-datasource-3.3.1.zip",
+              "md5": "2b0581be973eb2c30d669490d4503340"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3349,12 +3349,12 @@
         },
         {
           "version": "3.3.1",
-          "commit": "d3647bb4ade4c0617b480164aeb60c95ff9052af",
+          "commit": "fe467abbb6f77e95cba09ebf843ac516ee75dd85",
           "url": "https://github.com/instana/instana-grafana-datasource",
           "download": {
             "any": {
               "url": "https://github.com/instana/instana-grafana-datasource/releases/download/v3.3.1/instana-datasource-3.3.1.zip",
-              "md5": "2b0581be973eb2c30d669490d4503340"
+              "md5": "d12748315b5384a1c10c3126e72c55ff"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -3223,6 +3223,17 @@
               "md5": "961cf44ff5ee92d25f4c723a5c1d332b"
             }
           }
+        },
+        {
+          "version": "3.3.0",
+          "commit": "6631df7f04241e69b8503e28a4ceff06de2eed5b",
+          "url": "https://github.com/instana/instana-grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/instana/instana-grafana-datasource/releases/download/v3.3.0/instana-datasource-3.3.0.zip",
+              "md5": "4ac7c80f149f0a492657f4aa8d7a2130"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -3031,6 +3031,17 @@
               "md5": "6e4e3c4743cbf677cfcb5cc1c15dd7d8"
             }
           }
+        },
+        {
+          "version": "3.2.0",
+          "commit": "693ab9151fb01f835183af1a70e3cef92d879f0c",
+          "url": "https://github.com/instana/instana-grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/instana/instana-grafana-datasource/releases/download/v3.2.0/instana-datasource-3.2.0.zip",
+              "md5": "961cf44ff5ee92d25f4c723a5c1d332b"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
Adds a small fix to use newer Instana API payload and drop using deprecated payload.