### PR TITLE
Update macropower-analytics-panel to 2.0.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -5010,6 +5010,17 @@
               "md5": "1fba4f9f0c09a6f84c610626c86a221b"
             }
           }
+        },
+        {
+          "version": "2.0.1",
+          "commit": "18be95e87933686c94ef5fafa1b87609edbe4a7e",
+          "url": "https://github.com/MacroPower/macropower-analytics-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/MacroPower/macropower-analytics-panel/releases/download/v2.0.1/macropower-analytics-panel-2.0.1.zip",
+              "md5": "257c121ee91654260a8ac207f09287c8"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
This version primarily fixes Grafana 8.0.x compatibility. I had previously built on my own computer and must have gotten permissions wrong, because if you try to install v2.0.0 on Grafana 8 you get `access is forbidden to executable plugin file`. v2.0.1 switches to the release workflow which seems to have fixed this problem. There are also updates to dependencies, and a few style & documentation changes. Overall, the plugin itself should ideally behave the exact same between v2.0.0 and v2.0.1.

You can still use the `docker-compose` file, however you now need to build/download the plugin yourself, and I've had to pin Grafana to 7.5.10. On my computer the volume bind was resulting in +x always being set, and thus I couldn't run the plugin on 8.0.x this way.

```
docker-compose -f example/server/docker-compose.yaml up
```

Of course you can try changing Grafana to 8.0.x in the compose file, it's possible you'll have better luck on \<insert your non-Windows operating system here\>. If not you may have to go the normal route of manual install through grafana-cli --pluginUrl=...etc. My apologies if this causes you any difficulties during review. Please let me know if there are any issues / ways I could help. Thank you!