### PR TITLE
Add Kentik Connect App

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -7077,6 +7077,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "kentik-connect-app",
+      "type": "app",
+      "url": "https://github.com/kentik/kentik-grafana-app",
+      "versions": [
+        {
+          "version": "1.5.0",
+          "commit": "80700653974ad9186eb4372fbc6cbd6f8d7feaae",
+          "url": "https://github.com/kentik/kentik-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/kentik/kentik-grafana-app/releases/download/v1.5.0/kentik-connect-app-1.5.0.zip",
+              "md5": "9054b0b2476476f7f99363b4690a2df8"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR adds Kentik Connect Pro app, it needs review to be signed

### Plugin Validator check

![image](https://user-images.githubusercontent.com/1989898/128510811-5a98a227-4346-4de9-87cc-ec24743cc885.png)

### Test environment

```
docker run \
  -p 3000:3000 \
  -e "GF_INSTALL_PLUGINS=https://github.com/kentik/kentik-grafana-app/releases/download/v1.5.0/kentik-connect-app-1.5.0.zip;kentik-connect-app" \
  grafana/grafana:7.5.10
```

We can send credentials for testing via e-mail 