### PR TITLE
Update ae3e-plotly-panel to v0.5.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -5943,6 +5943,16 @@
               "md5": "94936b31096de4218a9c31f5ab2ab902"
             }
           }
+        },
+        {
+          "version": "0.4.0",
+          "url": "https://github.com/ae3e/ae3e-plotly-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/ae3e/ae3e-plotly-panel/releases/download/v0.4.0/ae3e-plotly-panel-0.4.0.zip",
+              "md5": "bafad6c9c14711f9c72624df398127a2"
+            }
+          }
         }
       ]
     },

--- a/repo.json
+++ b/repo.json
@@ -6495,6 +6495,16 @@
               "md5": "bafad6c9c14711f9c72624df398127a2"
             }
           }
+        },
+        {
+          "version": "0.5.0",
+          "url": "https://github.com/ae3e/ae3e-plotly-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/ae3e/ae3e-plotly-panel/releases/download/v0.5.0/ae3e-plotly-panel-0.5.0.zip",
+              "md5": "0a42052eb7becd36b10091ad9f6dabdb"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
Upgrade to Grafana 8 : https://github.com/ae3e/ae3e-plotly-panel/releases/tag/v0.5.0