### PR TITLE
Update VolkovLabs Image Panel 2.1.1

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -6967,6 +6967,17 @@
               "md5": "25fa95780b68370aefa5fe2c4612ffcb"
             }
           }
+        },
+        {
+          "version": "2.1.1",
+          "commit": "8341ff4dddaa8313aea3838ee3a323081bbd9156",
+          "url": "https://github.com/VolkovLabs/grafana-image-panel",
+          "download": {
+            "any": {
+              "url": "https://github.com/VolkovLabs/grafana-image-panel/releases/download/v2.1.1/volkovlabs-image-panel-2.1.1.zip",
+              "md5": "721c9443091921f6a5c8c2c0307292c6"
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
@marcusolsson Please review and update the Base64 Image panel.

To start please run `npm run start` to start Grafana with Marcus's Static data source.

## 2.1.1 (2021-08-18)

### Features / Enhancements

- Add Radio to select Image Size modes

## 2.1.0 (2021-08-12)

### Features / Enhancements

- Upgrade to Grafana 8.1.1
- Add Options and Fields to resize an image

![Screen Shot 2021-08-18 at 4 32 21 PM](https://user-images.githubusercontent.com/47795110/129969447-a3e65930-159f-4fd0-aef1-ea7fe1052dea.png)
