### PR TITLE
Add Kuma datasource plugin v0.0.4

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -7313,13 +7313,13 @@
       "url": "https://github.com/kumahq/kuma-grafana-datasource",
       "versions": [
         {
-          "version": "0.0.3",
-          "commit": "a8ef6eb0b71ca1c45a2600ef5eab5b47c0909b39",
+          "version": "0.0.4",
+          "commit": "3f25e05e492aefed327ad84a00778f0ca3c281a2",
           "url": "https://github.com/kumahq/kuma-grafana-datasource",
           "download": {
             "any": {
-              "url": "https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.0.3/kumahq-kuma-datasource-0.0.3.zip",
-              "md5": "348dff9c6a2543a0aca2a064c8526ff5"
+              "url": "https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.0.4/kumahq-kuma-datasource-0.0.4.zip",
+              "md5": "05df593cd1e1db856a023178a26ed754"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -7306,6 +7306,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "kumahq-kuma-datasource",
+      "type": "datasource",
+      "url": "https://github.com/kumahq/kuma-grafana-datasource",
+      "versions": [
+        {
+          "version": "0.0.3",
+          "commit": "a8ef6eb0b71ca1c45a2600ef5eab5b47c0909b39",
+          "url": "https://github.com/kumahq/kuma-grafana-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.0.3/kumahq-kuma-datasource-0.0.3.zip",
+              "md5": "348dff9c6a2543a0aca2a064c8526ff5"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This datasource enables to extract some information from the Kuma control-plane.
It also renders of nodeGraph panel from the status of the mesh.

How to setup:

- Follow the quickstart: https://kuma.io/docs/1.3.0/quickstart/kubernetes/
- As part of `kumactl install metrics` the kuma datasource is setup.