### PR TITLE
Zabbix plugin v4.2.2

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -353,6 +353,17 @@
       "url": "https://github.com/alexanderzobnin/grafana-zabbix",
       "versions": [
         {
+          "version": "4.2.2",
+          "url": "https://github.com/alexanderzobnin/grafana-zabbix",
+          "commit": "e9db978235cd6d01a095a37f3aa711ea8ea0f7ab",
+          "download": {
+            "any": {
+              "url": "https://github.com/alexanderzobnin/grafana-zabbix/releases/download/v4.2.2/alexanderzobnin-zabbix-app-4.2.2.zip",
+              "md5": "e182a4a76b0ea2327ff406ecb4fe2606"
+            }
+          }
+        },
+        {
           "version": "4.2.1",
           "url": "https://github.com/alexanderzobnin/grafana-zabbix",
           "commit": "95afc7460d112ea2467cf67866a3ae6e519972dc",


### PR DESCRIPTION
## [4.2.2] - 2021-08-25

### Fixed

- Different item intervals compatibility (stack graph issue), [#1211](https://github.com/alexanderzobnin/grafana-zabbix/issues/1211)
- Random "Failed to call resource" errors and plugin restarts, [#1269](https://github.com/alexanderzobnin/grafana-zabbix/issues/1269)
- Top function does not work if number of series less than provided N, [#1267](https://github.com/alexanderzobnin/grafana-zabbix/issues/1267)
- Hostnames are not displayed on multiple selection (regular expression), [#1265](https://github.com/alexanderzobnin/grafana-zabbix/issues/1265)
- Cannot unmarshal number into Go struct field ZabbixDatasourceSettingsDTO.timeout of type string, [#1254](https://github.com/alexanderzobnin/grafana-zabbix/issues/1254)
- `sortSeries()` does not sort by series name, [#1274](https://github.com/alexanderzobnin/grafana-zabbix/issues/1274)