### PR TITLE
Update tencentcloud-monitor-app to 2.2.2

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1,6 +1,34 @@
 {
   "plugins": [
     {
+      "id": "tencentcloud-monitor-app",
+      "type": "app",
+      "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+      "versions": [
+        {
+          "version": "2.0.0",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.0.0/tencentcloud-monitor-app-2.0.0.zip",
+              "md5": "2f9cfb5e7c9aa8219b2a12f3b82ada90"
+            }
+          }
+        },
+        {
+          "version": "2.0.1",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.0.1/tencentcloud-monitor-app-2.0.1.zip",
+              "md5": "e8aa900b6565b4d3b5cbdc6f5a806a4f"
+            }
+          }
+        }
+        
+      ]
+    },
+    {
       "id": "sskgo-perfcurve-panel",
       "type": "panel",
       "url": "https://github.com/SSKGo/perfcurve-panel",

--- a/repo.json
+++ b/repo.json
@@ -24,6 +24,16 @@
               "md5": "e8aa900b6565b4d3b5cbdc6f5a806a4f"
             }
           }
+        },
+        {
+          "version": "2.0.2",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.0.2/tencentcloud-monitor-app-2.0.2.zip",
+              "md5": "930e2d16f0ac9d703b12cfc7a0172ee3"
+            }
+          }
         }
         
       ]

--- a/repo.json
+++ b/repo.json
@@ -73,6 +73,16 @@
               "md5": "a0a877b1c762d7249d4aef42f92f784a"
             }
           }
+        },
+        {
+          "version": "2.2.0",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.2.0/tencentcloud-monitor-app-2.2.0.zip",
+              "md5": "406f39bfab69e5d7eaff0260ab6f6fb4"
+            }
+          }
         }
       ]
     },
@@ -6501,15 +6511,15 @@
           }
         },
         {
-            "version": "0.7.0",
-            "commit": "56b77e534ae79b82cecb7f2cc718fc0efb69b3d4",
-            "url": "https://github.com/yesoreyeram/grafana-infinity-datasource",
-            "download": {
-                "any": {
-                "url": "https://github.com/yesoreyeram/grafana-infinity-datasource/releases/download/v0.7.0/yesoreyeram-infinity-datasource-0.7.0.zip",
-                "md5": "8f27b7cf1904bf86b117f0fd0662f5dd"
-                }
+          "version": "0.7.0",
+          "commit": "56b77e534ae79b82cecb7f2cc718fc0efb69b3d4",
+          "url": "https://github.com/yesoreyeram/grafana-infinity-datasource",
+          "download": {
+            "any": {
+              "url": "https://github.com/yesoreyeram/grafana-infinity-datasource/releases/download/v0.7.0/yesoreyeram-infinity-datasource-0.7.0.zip",
+              "md5": "8f27b7cf1904bf86b117f0fd0662f5dd"
             }
+          }
         }
       ]
     },
@@ -6548,7 +6558,7 @@
         }
       ]
     },
-        {
+    {
       "id": "bmchelix-ade-datasource",
       "type": "datasource",
       "url": "https://github.com/bmcsoftware/bmchelix-datasource",

--- a/repo.json
+++ b/repo.json
@@ -83,6 +83,16 @@
               "md5": "406f39bfab69e5d7eaff0260ab6f6fb4"
             }
           }
+        },
+        {
+          "version": "2.2.1",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.2.1/tencentcloud-monitor-app-2.2.1.zip",
+              "md5": "869e0f59b98eadca3ad76ed69377865a"
+            }
+          }
         }
       ]
     },
@@ -6793,7 +6803,7 @@
         }
       ]
     },
- {
+    {
       "id": "sebastiangunreben-cdf-panel",
       "type": "panel",
       "url": "https://github.com/sebastiangunreben/sebastiangunreben-cdf-plugin",
@@ -6808,8 +6818,8 @@
             }
           }
         }
-        ]
-},
+      ]
+    },
     {
       "id": "teamviewer-datasource",
       "type": "datasource",
@@ -6874,6 +6884,6 @@
           }
         }
       ]
-    }    
+    }
   ]
 }

--- a/repo.json
+++ b/repo.json
@@ -15,8 +15,9 @@
               "md5": "d37c3d03656f84cb67537cf2f36f5912"
             }
           }
-        }]
-      },
+        }
+      ]
+    },
     {
       "id": "streamr-datasource",
       "type": "datasource",
@@ -108,6 +109,16 @@
             "any": {
               "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.2.1/tencentcloud-monitor-app-2.2.1.zip",
               "md5": "869e0f59b98eadca3ad76ed69377865a"
+            }
+          }
+        },
+        {
+          "version": "2.2.2",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.2.2/tencentcloud-monitor-app-2.2.2.zip",
+              "md5": "148e2e72b59a0377bf62d3cd8584c6d2"
             }
           }
         }

--- a/repo.json
+++ b/repo.json
@@ -34,6 +34,16 @@
               "md5": "930e2d16f0ac9d703b12cfc7a0172ee3"
             }
           }
+        },
+        {
+          "version": "2.1.0",
+          "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app",
+          "download": {
+            "any": {
+              "url": "https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/download/2.1.0/tencentcloud-monitor-app-2.1.0.zip",
+              "md5": "a0a877b1c762d7249d4aef42f92f784a"
+            }
+          }
         }
 
       ]


### PR DESCRIPTION
Hi, we would like to update a patch version to 2.2.2.

See [Changelog](https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/releases/tag/2.2.2) and [File Changes](https://github.com/TencentCloud/tencentcloud-monitor-grafana-app/compare/release/2.2.1...release/2.2.2).

Thanks.

![image](https://user-images.githubusercontent.com/36892657/131069274-21772333-e031-48e5-a19d-444608238839.png)
