### PR TITLE
add lework-lenav-panel v1.0.0

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -7246,6 +7246,24 @@
           }
         }
       ]
+    },
+    {
+      "id": "lework-lenav-panel",
+      "type": "panel",
+      "url": "https://github.com/lework/grafana-lenav-panel",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "commit": "a45348494ca8b1782e73d2c478fbc7ed1c0c1df7",
+          "url": "https://github.com/lework/grafana-lenav-panel/tree/v1.0.0",
+          "download": {
+            "any": {
+              "url": "https://github.com/lework/grafana-lenav-panel/releases/download/v1.0.0/grafana-lenav-panel-v1.0.0.zip",
+              "md5": "4f0d890700a5031cf4de284e853158e1"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
My first publish of a new plugin: lework-lenav-panel.

Readme:
https://github.com/lework/grafana-lenav-panel/blob/master/README.md

Release:
https://github.com/lework/grafana-lenav-panel/releases/tag/v1.0.0